### PR TITLE
Add toast notifications for restore & delete

### DIFF
--- a/Netflixx/Views/ProductionManager/Trash.cshtml
+++ b/Netflixx/Views/ProductionManager/Trash.cshtml
@@ -579,4 +579,36 @@
             addHiddenInputs(this, ids);
         });
     </script>
+    @if (TempData["SuccessMessage"] != null)
+    {
+        <script>
+            document.addEventListener('DOMContentLoaded', function () {
+                Swal.fire({
+                    toast: true,
+                    position: 'bottom-end',
+                    icon: 'success',
+                    title: '@TempData["SuccessMessage"]',
+                    showConfirmButton: false,
+                    timer: 3000,
+                    timerProgressBar: true
+                });
+            });
+        </script>
+    }
+    @if (TempData["ErrorMessage"] != null)
+    {
+        <script>
+            document.addEventListener('DOMContentLoaded', function () {
+                Swal.fire({
+                    toast: true,
+                    position: 'bottom-end',
+                    icon: 'error',
+                    title: '@TempData["ErrorMessage"]',
+                    showConfirmButton: false,
+                    timer: 3000,
+                    timerProgressBar: true
+                });
+            });
+        </script>
+    }
 }


### PR DESCRIPTION
## Summary
- show SweetAlert toast when restoring or permanently deleting items from trash

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68527002c9008327b2022af9a35c5750