### PR TITLE
Align ProductionManager forms with Trash design

### DIFF
--- a/Netflixx/Views/ProductionManager/Create.cshtml
+++ b/Netflixx/Views/ProductionManager/Create.cshtml
@@ -206,12 +206,68 @@
         border-color: #555;
         color: #fff;
     }
+
+    /* Page Header */
+    .page-header {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        flex-wrap: wrap;
+        gap: 1rem;
+    }
+
+    .page-title {
+        color: #fff;
+        font-weight: 600;
+        font-size: 1.75rem;
+    }
+
+    .header-stats {
+        display: flex;
+        gap: 1rem;
+    }
+
+    .stat-badge {
+        background: linear-gradient(135deg, #ffc107 0%, #ffca2c 100%);
+        color: #000;
+        padding: 0.5rem 1rem;
+        border-radius: 25px;
+        text-align: center;
+        font-weight: 600;
+        min-width: 100px;
+    }
+
+    .stat-number {
+        display: block;
+        font-size: 1.5rem;
+        line-height: 1;
+    }
+
+    .stat-label {
+        font-size: 0.8rem;
+        opacity: 0.8;
+    }
 </style>
 
 @await Html.PartialAsync("_ProductionManagerMenu")
 
 <div class="main-content" id="mainContent">
-    <div class="container-fluid">
+    <div class="container-fluid px-4 py-3">
+        <!-- Header Section -->
+        <div class="row mb-4">
+            <div class="col-12">
+                <div class="page-header">
+                    <div class="header-content">
+                        <h2 class="page-title mb-0">
+                            <i class="fas fa-plus me-2 text-success"></i>
+                            Thêm Công ty Sản xuất
+                        </h2>
+                        <p class="text-muted mb-0">Tạo công ty sản xuất mới</p>
+                    </div>
+                </div>
+            </div>
+        </div>
+
         <div class="row">
             <div class="col-md-10 offset-md-1">
                 <div class="card shadow">

--- a/Netflixx/Views/ProductionManager/Edit.cshtml
+++ b/Netflixx/Views/ProductionManager/Edit.cshtml
@@ -208,12 +208,68 @@
         border-color: #555;
         color: #fff;
     }
+
+    /* Page Header */
+    .page-header {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        flex-wrap: wrap;
+        gap: 1rem;
+    }
+
+    .page-title {
+        color: #fff;
+        font-weight: 600;
+        font-size: 1.75rem;
+    }
+
+    .header-stats {
+        display: flex;
+        gap: 1rem;
+    }
+
+    .stat-badge {
+        background: linear-gradient(135deg, #ffc107 0%, #ffca2c 100%);
+        color: #000;
+        padding: 0.5rem 1rem;
+        border-radius: 25px;
+        text-align: center;
+        font-weight: 600;
+        min-width: 100px;
+    }
+
+    .stat-number {
+        display: block;
+        font-size: 1.5rem;
+        line-height: 1;
+    }
+
+    .stat-label {
+        font-size: 0.8rem;
+        opacity: 0.8;
+    }
 </style>
 
 @await Html.PartialAsync("_ProductionManagerMenu")
 
 <div class="main-content" id="mainContent">
-    <div class="container-fluid">
+    <div class="container-fluid px-4 py-3">
+        <!-- Header Section -->
+        <div class="row mb-4">
+            <div class="col-12">
+                <div class="page-header">
+                    <div class="header-content">
+                        <h2 class="page-title mb-0">
+                            <i class="fas fa-edit me-2 text-info"></i>
+                            Chỉnh sửa Công ty Sản xuất
+                        </h2>
+                        <p class="text-muted mb-0">Cập nhật thông tin @Model.Name</p>
+                    </div>
+                </div>
+            </div>
+        </div>
+
         <div class="row">
             <div class="col-md-10 offset-md-1">
                 <div class="card shadow">


### PR DESCRIPTION
## Summary
- sync ProductionManager create and edit pages with trash page look
- add page header section and common styles for these forms

## Testing
- `npm run scss` *(fails: `sass` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852757f16bc83278cc3948278959ec2