### PR TITLE
Remove red headers from production forms

### DIFF
--- a/Netflixx/Views/ProductionManager/Create.cshtml
+++ b/Netflixx/Views/ProductionManager/Create.cshtml
@@ -271,13 +271,6 @@
         <div class="row">
             <div class="col-md-10 offset-md-1">
                 <div class="card shadow">
-                    <div class="card-header">
-                        <h3 class="card-title mb-0">
-                            <i class="fas fa-plus mr-2"></i>
-                            Thêm Công ty Sản xuất mới
-                        </h3>
-                    </div>
-
                     <div class="card-body">
                         <form asp-action="Create" method="post" enctype="multipart/form-data" novalidate>
                             <div asp-validation-summary="ModelOnly" class="alert alert-danger" role="alert"></div>

--- a/Netflixx/Views/ProductionManager/Edit.cshtml
+++ b/Netflixx/Views/ProductionManager/Edit.cshtml
@@ -273,13 +273,6 @@
         <div class="row">
             <div class="col-md-10 offset-md-1">
                 <div class="card shadow">
-                    <div class="card-header">
-                        <h3 class="card-title mb-0">
-                            <i class="fas fa-edit mr-2"></i>
-                            Chỉnh sửa Công ty Sản xuất: @Model.Name
-                        </h3>
-                    </div>
-
                     <div class="card-body">
                         <form asp-action="Edit" method="post" enctype="multipart/form-data" novalidate>
                             <input type="hidden" asp-for="Id" />


### PR DESCRIPTION
## Summary
- remove red `card-header` sections from create and edit production company pages

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68527758e0808327bc034bfc87372094