### PR TITLE
Add confirmation page for bulk hard delete

### DIFF
--- a/Netflixx/Controllers/ProductionManagerController.cs
+++ b/Netflixx/Controllers/ProductionManagerController.cs
@@ -458,6 +458,22 @@ namespace Netflixx.Controllers
             return RedirectToAction(nameof(Trash));
         }
 
+        [HttpGet]
+        public async Task<IActionResult> HardDeleteSelected([FromQuery] int[] ids)
+        {
+            if (ids == null || ids.Length == 0)
+            {
+                TempData["ErrorMessage"] = "Vui lòng chọn ít nhất một mục.";
+                return RedirectToAction(nameof(Trash));
+            }
+
+            var managers = await _context.ProductionManagers
+                .Where(pm => ids.Contains(pm.Id))
+                .ToListAsync();
+
+            return View("HardDeleteSelected", managers);
+        }
+
         [HttpPost]
         [ValidateAntiForgeryToken]
         public async Task<IActionResult> HardDeleteSelected([FromForm] int[] ids)

--- a/Netflixx/Views/ProductionManager/HardDeleteSelected.cshtml
+++ b/Netflixx/Views/ProductionManager/HardDeleteSelected.cshtml
@@ -1,0 +1,47 @@
+@model IEnumerable<ProductionManagerApp.Models.ProductionManager>
+@{
+    ViewData["Title"] = "Xóa vĩnh viễn các mục đã chọn";
+}
+
+@await Html.PartialAsync("_ProductionManagerMenu")
+
+<div class="main-content" id="mainContent">
+    <div class="container-fluid px-4 py-3">
+        <div class="row mb-4">
+            <div class="col-12">
+                <h2 class="page-title mb-0">
+                    <i class="fas fa-trash-alt me-2 text-warning"></i>@ViewData["Title"]
+                </h2>
+            </div>
+        </div>
+        <div class="row">
+            <div class="col-12">
+                <div class="card bg-dark text-light">
+                    <div class="card-body">
+                        <p>Bạn có chắc chắn muốn xóa vĩnh viễn các mục sau đây?</p>
+                        <ul>
+                            @foreach (var item in Model)
+                            {
+                                <li>@item.Name</li>
+                            }
+                        </ul>
+                        <form asp-action="HardDeleteSelected" method="post">
+                            @foreach (var item in Model)
+                            {
+                                <input type="hidden" name="ids" value="@item.Id" />
+                            }
+                            <button type="submit" class="btn btn-danger me-2">
+                                <i class="fas fa-trash-alt me-1"></i>Xác nhận xóa vĩnh viễn
+                            </button>
+                            <a asp-action="Trash" class="btn btn-secondary">
+                                <i class="fas fa-times me-1"></i>Hủy bỏ
+                            </a>
+                        </form>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+@await Html.PartialAsync("_ProductionManagerMenuScripts")

--- a/Netflixx/Views/ProductionManager/Trash.cshtml
+++ b/Netflixx/Views/ProductionManager/Trash.cshtml
@@ -53,8 +53,7 @@
                                         <i class="fas fa-undo me-1"></i>Khôi phục đã chọn
                                     </button>
                                 </form>
-                                <form asp-action="HardDeleteSelected" method="post" id="deleteSelectedForm" class="d-inline-block" onsubmit="return confirm('Bạn có chắc muốn xóa vĩnh viễn các mục đã chọn?');">
-                                    @Html.AntiForgeryToken()
+                                <form asp-action="HardDeleteSelected" method="get" id="deleteSelectedForm" class="d-inline-block">
                                     <button type="submit" class="btn btn-danger btn-sm">
                                         <i class="fas fa-times me-1"></i>Xóa
                                         vĩnh viễn


### PR DESCRIPTION
## Summary
- add a `HardDeleteSelected` confirmation view
- support GET `HardDeleteSelected` in controller
- route trash bulk delete button to the new confirmation page

## Testing
- `npm run scss` *(fails: sass not found)*

------
https://chatgpt.com/codex/tasks/task_e_68527989234083278bdb240dd800c270