### PR TITLE
Fix hard delete modal trigger

### DIFF
--- a/Netflixx/Views/ProductionManager/Trash.cshtml
+++ b/Netflixx/Views/ProductionManager/Trash.cshtml
@@ -109,9 +109,9 @@
                                                 <i class="fas fa-undo me-1"></i>Khôi phục
                                             </button>
                                         </form>
-                                        <a asp-action="HardDelete" asp-route-id="@item.Id" class="btn btn-danger btn-sm hard-delete-link" title="Xóa vĩnh viễn">
+                                        <button type="button" data-url="@Url.Action("HardDelete", new { id = item.Id })" class="btn btn-danger btn-sm hard-delete-link" title="Xóa vĩnh viễn">
                                             <i class="fas fa-times me-1"></i>Xóa vĩnh viễn
-                                        </a>
+                                        </button>
                                     </div>
                                 </div>
                             }
@@ -157,9 +157,9 @@
                                                     <i class="fas fa-undo me-1"></i>Khôi phục
                                                 </button>
                                             </form>
-                                            <a asp-action="HardDelete" asp-route-id="@item.Id" class="btn btn-danger btn-sm hard-delete-link" title="Xóa vĩnh viễn">
+                                            <button type="button" data-url="@Url.Action("HardDelete", new { id = item.Id })" class="btn btn-danger btn-sm hard-delete-link" title="Xóa vĩnh viễn">
                                                 <i class="fas fa-times me-1"></i>Xóa vĩnh viễn
-                                            </a>
+                                            </button>
                                         </div>
                                     </div>
                                 }
@@ -741,7 +741,7 @@
             var hardDeleteModal = new bootstrap.Modal(document.getElementById('hardDeleteModal'));
             $('body').on('click', '.hard-delete-link', function (e) {
                 e.preventDefault();
-                var url = $(this).attr('href');
+                var url = $(this).data('url');
                 $('#hardDeleteModalContainer').load(url, function () {
                     hardDeleteModal.show();
                 });


### PR DESCRIPTION
## Summary
- change hard delete link to button in `Trash.cshtml`
- load the modal using the button's `data-url` attribute

## Testing
- `npm run scss` *(fails: sass not found)*

------
https://chatgpt.com/codex/tasks/task_e_685280e0852c832788a8ca99ce0e00a3