### PR TITLE
Ensure back button returns to history list

### DIFF
--- a/Netflixx/Controllers/ProductionManagerController.cs
+++ b/Netflixx/Controllers/ProductionManagerController.cs
@@ -367,7 +367,7 @@ namespace Netflixx.Controllers
         }
 
         [HttpGet]
-        public async Task<IActionResult> HistoryDetails(int id)
+        public async Task<IActionResult> HistoryDetails(int id, string returnTo = null)
         {
             var history = await _context.ProductionManagerHistories
                 .Include(h => h.ProductionManager)
@@ -376,6 +376,7 @@ namespace Netflixx.Controllers
             {
                 return NotFound();
             }
+            ViewBag.ReturnTo = returnTo;
             return View("HistoryDetails", history);
         }
         [HttpGet]

--- a/Netflixx/Views/ProductionManager/HistoryAll.cshtml
+++ b/Netflixx/Views/ProductionManager/HistoryAll.cshtml
@@ -212,7 +212,7 @@
                                     <td>@(item.ProductionManagerName ?? item.ProductionManager?.Name)</td>
                                     <td>@item.Action</td>
                                     <td>
-                                        <a asp-action="HistoryDetails" asp-route-id="@item.Id" class="btn btn-sm btn-info">
+                                        <a asp-action="HistoryDetails" asp-route-id="@item.Id" asp-route-returnTo="HistoryAll" class="btn btn-sm btn-info">
                                             Xem
                                         </a>
                                     </td>

--- a/Netflixx/Views/ProductionManager/HistoryDetails.cshtml
+++ b/Netflixx/Views/ProductionManager/HistoryDetails.cshtml
@@ -28,7 +28,13 @@
                 </dl>
             </div>
             <div class="card-footer text-center">
-                <a asp-action="History" asp-route-id="@Model.ProductionManagerId" class="btn btn-outline-light">
+                @{
+                    var returnTo = ViewBag.ReturnTo as string;
+                    string href = returnTo == "HistoryAll"
+                        ? Url.Action("HistoryAll")
+                        : Url.Action("History", new { id = Model.ProductionManagerId });
+                }
+                <a href="@href" class="btn btn-outline-light">
                     <i class="fas fa-arrow-left"></i> Quay lại
                 </a>
             </div>


### PR DESCRIPTION
## Summary
- keep track of the source page for HistoryDetails
- route back to HistoryAll when HistoryDetails opened from HistoryAll

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852b40f89d48327a3d93a7a03a7fd1e