### PR TITLE
Sync history views with trash layout

### DIFF
--- a/Netflixx/Views/ProductionManager/History.cshtml
+++ b/Netflixx/Views/ProductionManager/History.cshtml
@@ -5,6 +5,7 @@
 
 @section Styles {
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css" />
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.7.2/font/bootstrap-icons.css" rel="stylesheet">
 }
 
 <style>
@@ -126,12 +127,65 @@
     .table-striped tbody tr:nth-of-type(odd) {
         background-color: #3c3c3c;
     }
+    /* Header styles borrowed from Trash page */
+    .page-header {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        flex-wrap: wrap;
+        gap: 1rem;
+    }
+
+    .page-title {
+        color: #fff;
+        font-weight: 600;
+        font-size: 1.75rem;
+    }
+
+    .header-stats {
+        display: flex;
+        gap: 1rem;
+    }
+
+    .stat-badge {
+        background: linear-gradient(135deg, #ffc107 0%, #ffca2c 100%);
+        color: #000;
+        padding: 0.5rem 1rem;
+        border-radius: 25px;
+        text-align: center;
+        font-weight: 600;
+        min-width: 100px;
+    }
+
+    .stat-number {
+        display: block;
+        font-size: 1.5rem;
+        line-height: 1;
+    }
+
+    .stat-label {
+        font-size: 0.8rem;
+        opacity: 0.8;
+    }
 </style>
 
 @await Html.PartialAsync("_ProductionManagerMenu")
 
 <div class="main-content" id="mainContent">
-    <div class="container mt-4">
+    <div class="container-fluid px-4 py-3">
+        <!-- Header Section -->
+        <div class="row mb-4">
+            <div class="col-12">
+                <div class="page-header">
+                    <div class="header-content">
+                        <h2 class="page-title mb-0">
+                            <i class="fas fa-history me-2 text-info"></i>
+                            Lịch sử chỉnh sửa
+                        </h2>
+                    </div>
+                </div>
+            </div>
+        </div>
         <div class="card bg-dark text-white shadow-lg">
             <div class="card-header">
                 <h4><i class="fas fa-history"></i> Lịch sử chỉnh sửa</h4>

--- a/Netflixx/Views/ProductionManager/HistoryAll.cshtml
+++ b/Netflixx/Views/ProductionManager/HistoryAll.cshtml
@@ -5,6 +5,7 @@
 
 @section Styles {
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css" />
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.7.2/font/bootstrap-icons.css" rel="stylesheet">
 }
 
 <style>
@@ -141,12 +142,66 @@
         .form-control::placeholder {
             color: #aaa;
         }
+    /* Header styles borrowed from Trash page */
+    .page-header {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        flex-wrap: wrap;
+        gap: 1rem;
+    }
+
+    .page-title {
+        color: #fff;
+        font-weight: 600;
+        font-size: 1.75rem;
+    }
+
+    .header-stats {
+        display: flex;
+        gap: 1rem;
+    }
+
+    .stat-badge {
+        background: linear-gradient(135deg, #ffc107 0%, #ffca2c 100%);
+        color: #000;
+        padding: 0.5rem 1rem;
+        border-radius: 25px;
+        text-align: center;
+        font-weight: 600;
+        min-width: 100px;
+    }
+
+    .stat-number {
+        display: block;
+        font-size: 1.5rem;
+        line-height: 1;
+    }
+
+    .stat-label {
+        font-size: 0.8rem;
+        opacity: 0.8;
+    }
 </style>
 
 @await Html.PartialAsync("_ProductionManagerMenu")
 
 <div class="main-content" id="mainContent">
-    <div class="container mt-4">
+    <div class="container-fluid px-4 py-3">
+        <!-- Header Section -->
+        <div class="row mb-4">
+            <div class="col-12">
+                <div class="page-header">
+                    <div class="header-content">
+                        <h2 class="page-title mb-0">
+                            <i class="fas fa-history me-2 text-info"></i>
+                            Tất cả thay đổi
+                        </h2>
+                        <p class="text-muted mb-0">Danh sách lịch sử chỉnh sửa</p>
+                    </div>
+                </div>
+            </div>
+        </div>
         <!-- Card tìm kiếm và lọc -->
         <div class="card shadow filter-card">
             <div class="card-header">


### PR DESCRIPTION
## Summary
- add Bootstrap icons and page header styles to history pages
- add header section markup so history pages match the trash page design

## Testing
- `npm run scss` *(fails: Can't find stylesheet to import)*

------
https://chatgpt.com/codex/tasks/task_e_6852b4ea8ed0832791060ca00713d3a2