### PR TITLE
Add package management via database

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -361,3 +361,7 @@ MigrationBackup/
 
 # Fody - auto-generated XML schema
 FodyWeavers.xsd
+
+# Allow package management views
+!Netflixx/Areas/Admin/Views/Packages/
+!Netflixx/Areas/Admin/Views/Packages/**

--- a/Netflixx/Areas/Admin/Controllers/PackagesController.cs
+++ b/Netflixx/Areas/Admin/Controllers/PackagesController.cs
@@ -1,0 +1,52 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Netflixx.Models;
+using Netflixx.Repositories;
+using System.Threading.Tasks;
+
+[Area("Admin")]
+public class PackagesController : Controller
+{
+    private readonly DBContext _context;
+    public PackagesController(DBContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<IActionResult> Index()
+    {
+        var packages = await _context.Packages.ToListAsync();
+        return View(packages);
+    }
+
+    public IActionResult Create()
+    {
+        return View();
+    }
+
+    [HttpPost]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> Create(PackagesModel model)
+    {
+        if (ModelState.IsValid)
+        {
+            _context.Packages.Add(model);
+            await _context.SaveChangesAsync();
+            return RedirectToAction(nameof(Index));
+        }
+        return View(model);
+    }
+
+    [HttpPost]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> Delete(int id)
+    {
+        var pkg = await _context.Packages.FindAsync(id);
+        if (pkg != null)
+        {
+            _context.Packages.Remove(pkg);
+            await _context.SaveChangesAsync();
+        }
+        return RedirectToAction(nameof(Index));
+    }
+}

--- a/Netflixx/Areas/Admin/Views/Packages/Create.cshtml
+++ b/Netflixx/Areas/Admin/Views/Packages/Create.cshtml
@@ -1,0 +1,23 @@
+@model Netflixx.Models.PackagesModel
+@{
+    ViewData["Title"] = "Create Package";
+}
+<h2>Tạo gói mới</h2>
+<form asp-action="Create" method="post">
+    <div class="mb-3">
+        <label asp-for="Name" class="form-label"></label>
+        <input asp-for="Name" class="form-control" />
+        <span asp-validation-for="Name" class="text-danger"></span>
+    </div>
+    <div class="mb-3">
+        <label asp-for="Price" class="form-label"></label>
+        <input asp-for="Price" class="form-control" />
+        <span asp-validation-for="Price" class="text-danger"></span>
+    </div>
+    <div class="mb-3">
+        <label asp-for="Description" class="form-label"></label>
+        <textarea asp-for="Description" class="form-control"></textarea>
+    </div>
+    <button type="submit" class="btn btn-primary">Tạo</button>
+    <a asp-action="Index" class="btn btn-secondary">Hủy</a>
+</form>

--- a/Netflixx/Areas/Admin/Views/Packages/Index.cshtml
+++ b/Netflixx/Areas/Admin/Views/Packages/Index.cshtml
@@ -1,0 +1,31 @@
+@model IEnumerable<Netflixx.Models.PackagesModel>
+@{
+    ViewData["Title"] = "Packages";
+}
+<h2>Danh sách gói</h2>
+<a asp-action="Create" class="btn btn-primary">Tạo gói mới</a>
+<table class="table mt-3">
+    <thead>
+        <tr>
+            <th>Tên</th>
+            <th>Giá</th>
+            <th>Mô tả</th>
+            <th></th>
+        </tr>
+    </thead>
+    <tbody>
+@foreach (var item in Model)
+{
+        <tr>
+            <td>@item.Name</td>
+            <td>@item.Price.ToString("N0") đ</td>
+            <td>@item.Description</td>
+            <td>
+                <form asp-action="Delete" method="post" asp-route-id="@item.Id" style="display:inline">
+                    <button type="submit" class="btn btn-sm btn-danger">Xóa</button>
+                </form>
+            </td>
+        </tr>
+}
+    </tbody>
+</table>

--- a/Netflixx/Areas/Admin/Views/Shared/_AdminLayout.cshtml
+++ b/Netflixx/Areas/Admin/Views/Shared/_AdminLayout.cshtml
@@ -39,6 +39,11 @@
                 <span>Quản lý người dùng</span>
             </a>
 
+            <a href="/Admin/Packages" class="sidebar-item">
+                <i class="fas fa-box"></i>
+                <span>Quản lý gói</span>
+            </a>
+
             <a href="/Admin/Transactions" class="sidebar-item">
                 <i class="fas fa-receipt"></i>
                 <span>Giao dịch</span>

--- a/Netflixx/Controllers/FilmpackageController.cs
+++ b/Netflixx/Controllers/FilmpackageController.cs
@@ -1,10 +1,18 @@
 ﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
 using Netflixx.Models;
+using Netflixx.Repositories;
 
 namespace Netflixx.Controllers
 {
     public class FilmpackageController : Controller
     {
+        private readonly DBContext _context;
+        public FilmpackageController(DBContext context)
+        {
+            _context = context;
+        }
+
         public IActionResult Index()
         {
             return View();
@@ -25,6 +33,14 @@ namespace Netflixx.Controllers
             };
 
             return View(model);
+        }
+
+        public async Task<IActionResult> GetPackages()
+        {
+            var packages = await _context.Packages
+                .Select(p => new { id = p.Id, name = p.Name, price = p.Price, description = p.Description })
+                .ToListAsync();
+            return Json(packages);
         }
 
     }

--- a/Netflixx/Models/PackagesModel.cs
+++ b/Netflixx/Models/PackagesModel.cs
@@ -1,4 +1,5 @@
 ﻿using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
 
 namespace Netflixx.Models
 {
@@ -10,6 +11,10 @@ namespace Netflixx.Models
         [Required(ErrorMessage = "Tên không được để trống.")]
         public string Name { get; set; }
         public string? Description { get; set; }
+
+        [Column(TypeName = "decimal(18,2)")]
+        [Range(0, double.MaxValue)]
+        public decimal Price { get; set; }
 
         // Navigation properties
         public ICollection<PackageChannelsModel> PackageChannels { get; set; }

--- a/Netflixx/wwwroot/js/Filmpackage.js
+++ b/Netflixx/wwwroot/js/Filmpackage.js
@@ -1,98 +1,33 @@
-﻿let filmpackage = [
-    {
-        packageId: "package01",
-        packageName: "Cơ Bản",
-        packagePrice: 0,
-        features: [
-            "Xem một số phim và chương trình miễn phí",
-            "Chất lượng video HD (720p)",
-            "× Tải xuống",
-            "× Không quảng cáo",
-            "× Không giới hạn thiết bị"
-        ],
-        btnClass: "basic-btn"
-    },
-    {
-        packageId: "package02",
-        packageName: "Tiêu Chuẩn",
-        packagePrice: 99000,
-        features: [
-            "Tất cả tính năng của gói Cơ Bản",
-            "Thoải mái xem tất cả các phim",
-            "Chất lượng video Full HD (1080p)",
-            "Xem trên 2 thiết bị cùng lúc",
-            "Không quảng cáo",
-            "Tải xuống"
-        ],
-        btnClass: "standard-btn"
-    },
-    {
-        packageId: "package03",
-        packageName: "Cao Cấp",
-        packagePrice: 149000,
-        features: [
-            "Tất cả tính năng của gói Tiêu Chuẩn",
-            "Xem trên 4 thiết bị cùng lúc",
-            "Chất lượng video Ultra HD (4K) và HDR",
-            "Âm thanh Dolby Atmos",
-            "Hỗ trợ khách hàng nhanh (ưu tiên)"
-        ],
-        btnClass: "premium-btn"
-    }
-];
-
 document.addEventListener('DOMContentLoaded', () => {
     const packageContainer = document.querySelector('.package-container');
 
-    filmpackage.forEach(pkg => {
-        // Tạo HTML cho mỗi gói
-        const card = document.createElement('div');
-        card.classList.add('package-card');
+    fetch('/Filmpackage/GetPackages')
+        .then(res => res.json())
+        .then(data => {
+            data.forEach(pkg => {
+                const card = document.createElement('div');
+                card.classList.add('package-card');
+                const headerClass = pkg.name === 'Cơ Bản' ? 'basic' :
+                    pkg.name === 'Tiêu Chuẩn' ? 'standard' : 'premium';
+                const header = `
+                    <div class="package-header ${headerClass}">
+                        <h2>${pkg.name}</h2>
+                        <div class="price">${Number(pkg.price).toLocaleString()}đ <span>/tháng</span></div>
+                    </div>`;
+                const description = pkg.description ? `<p>${pkg.description}</p>` : '';
+                const btnClass = headerClass + '-btn';
+                const buttonHTML = `<button class="${btnClass}" data-id="${pkg.id}" data-name="${pkg.name}" data-price="${pkg.price}">Đăng ký ngay</button>`;
+                card.innerHTML = header + description + buttonHTML;
+                packageContainer.appendChild(card);
+            });
+        });
 
-        const headerClass = pkg.packageName === "Cơ Bản" ? "basic" :
-            pkg.packageName === "Tiêu Chuẩn" ? "standard" : "premium";
-
-        // Tạo phần header
-        const header = `
-            <div class="package-header ${headerClass}">
-                <h2>${pkg.packageName}</h2>
-                <div class="price">${pkg.packagePrice.toLocaleString()}đ <span>/tháng</span></div>
-            </div>
-        `;
-
-        // Tạo danh sách tính năng
-        const features = pkg.features.map(feature => {
-            const icon = feature.startsWith("×") ? "×" : "✓";
-            const text = feature.replace(/^✓ |^× /, '');
-            return `
-                <div class="feature">
-                    <div class="feature-icon">${icon}</div>
-                    <div class="feature-text">${text}</div>
-                </div>
-            `;
-        }).join("");
-
-        const featuresHTML = `<div class="package-features">${features}</div>`;
-
-        // Thêm data attributes để truyền dữ liệu cho trang thanh toán
-        const buttonHTML = `<button class="${pkg.btnClass}" data-id="${pkg.packageId}" data-name="${pkg.packageName}" data-price="${pkg.packagePrice}">Đăng ký ngay</button>`;
-
-        card.innerHTML = header + featuresHTML + buttonHTML;
-
-        // Thêm thẻ vào container
-        packageContainer.appendChild(card);
-    });
-
-    // Sự kiện click cho toàn bộ container (event delegation)
     packageContainer.addEventListener('click', (e) => {
         if (e.target.tagName === 'BUTTON') {
             const btn = e.target;
-
             const packageId = btn.dataset.id;
             const packageName = encodeURIComponent(btn.dataset.name);
             const packagePrice = btn.dataset.price;
-
-            // Điều hướng đến trang thanh toán với thông tin gói
             window.location.href = `/Filmpackage/Buy?packageId=${packageId}&packageName=${packageName}&packagePrice=${packagePrice}`;
         }
     });


### PR DESCRIPTION
## Summary
- allow customizing packages via new admin controller
- display package management link in admin layout
- fetch package data from backend API instead of static JS
- store price for packages in database model

## Testing
- `npm run scss` *(fails: sass not found)*

------
https://chatgpt.com/codex/tasks/task_e_68566ae90fe883278a7bf1e96a840f86