### PR TITLE
Fix numeric input for package price

### DIFF
--- a/Netflixx/Areas/Admin/Views/Packages/Create.cshtml
+++ b/Netflixx/Areas/Admin/Views/Packages/Create.cshtml
@@ -11,7 +11,7 @@
     </div>
     <div class="mb-3">
         <label asp-for="Price" class="form-label"></label>
-        <input asp-for="Price" class="form-control" placeholder="Giá VNĐ" />
+        <input asp-for="Price" class="form-control" placeholder="Giá VNĐ" type="number" step="0.01" min="0" />
         <span asp-validation-for="Price" class="text-danger"></span>
     </div>
     <div class="mb-3">

--- a/Netflixx/Views/Packages/Create.cshtml
+++ b/Netflixx/Views/Packages/Create.cshtml
@@ -11,7 +11,7 @@
     </div>
     <div class="mb-3">
         <label asp-for="Price" class="form-label"></label>
-        <input asp-for="Price" class="form-control" placeholder="Giá VNĐ" />
+        <input asp-for="Price" class="form-control" placeholder="Giá VNĐ" type="number" step="0.01" min="0" />
         <span asp-validation-for="Price" class="text-danger"></span>
     </div>
     <div class="mb-3">


### PR DESCRIPTION
## Summary
- ensure price uses numeric input on package create pages

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68567c90ed2c8327b00a7c1717345c85