### PR TITLE
Add packages CRUD pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -197,9 +197,11 @@ PublishScripts/
 # NuGet Symbol Packages
 *.snupkg
 # The packages folder can be ignored because of Package Restore
+# Ignore global packages folder but keep MVC Packages views
 **/[Pp]ackages/*
 # except build/, which is used as an MSBuild target.
 !**/[Pp]ackages/build/
+!Netflixx/Views/Packages/**
 # Uncomment if necessary however generally it will be regenerated when needed
 #!**/[Pp]ackages/repositories.config
 # NuGet v3's project.json files produces more ignorable files

--- a/Netflixx/Controllers/PackagesController.cs
+++ b/Netflixx/Controllers/PackagesController.cs
@@ -1,0 +1,139 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Netflixx.Models;
+using Netflixx.Repositories;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Netflixx.Controllers
+{
+    public class PackagesController : Controller
+    {
+        private readonly DBContext _context;
+
+        public PackagesController(DBContext context)
+        {
+            _context = context;
+        }
+
+        // GET: Packages
+        public async Task<IActionResult> Index()
+        {
+            var packages = await _context.Packages.ToListAsync();
+            return View(packages);
+        }
+
+        // GET: Packages/Create
+        [Authorize(Roles = "Admin,Manager")]
+        public IActionResult Create()
+        {
+            return View();
+        }
+
+        // POST: Packages/Create
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        [Authorize(Roles = "Admin,Manager")]
+        public async Task<IActionResult> Create(PackagesModel package)
+        {
+            if (ModelState.IsValid)
+            {
+                _context.Add(package);
+                await _context.SaveChangesAsync();
+                return RedirectToAction(nameof(Index));
+            }
+            return View(package);
+        }
+
+        // GET: Packages/Edit/5
+        [Authorize(Roles = "Admin,Manager")]
+        public async Task<IActionResult> Edit(int? id)
+        {
+            if (id == null)
+            {
+                return NotFound();
+            }
+
+            var package = await _context.Packages.FindAsync(id);
+            if (package == null)
+            {
+                return NotFound();
+            }
+            return View(package);
+        }
+
+        // POST: Packages/Edit/5
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        [Authorize(Roles = "Admin,Manager")]
+        public async Task<IActionResult> Edit(int id, PackagesModel package)
+        {
+            if (id != package.Id)
+            {
+                return NotFound();
+            }
+
+            if (ModelState.IsValid)
+            {
+                try
+                {
+                    _context.Update(package);
+                    await _context.SaveChangesAsync();
+                }
+                catch (DbUpdateConcurrencyException)
+                {
+                    if (!PackageExists(package.Id))
+                    {
+                        return NotFound();
+                    }
+                    else
+                    {
+                        throw;
+                    }
+                }
+                return RedirectToAction(nameof(Index));
+            }
+            return View(package);
+        }
+
+        // GET: Packages/Delete/5
+        [Authorize(Roles = "Admin,Manager")]
+        public async Task<IActionResult> Delete(int? id)
+        {
+            if (id == null)
+            {
+                return NotFound();
+            }
+
+            var package = await _context.Packages
+                .FirstOrDefaultAsync(m => m.Id == id);
+            if (package == null)
+            {
+                return NotFound();
+            }
+
+            return View(package);
+        }
+
+        // POST: Packages/Delete/5
+        [HttpPost, ActionName("Delete")]
+        [ValidateAntiForgeryToken]
+        [Authorize(Roles = "Admin,Manager")]
+        public async Task<IActionResult> DeleteConfirmed(int id)
+        {
+            var package = await _context.Packages.FindAsync(id);
+            if (package != null)
+            {
+                _context.Packages.Remove(package);
+                await _context.SaveChangesAsync();
+            }
+            return RedirectToAction(nameof(Index));
+        }
+
+        private bool PackageExists(int id)
+        {
+            return _context.Packages.Any(e => e.Id == id);
+        }
+    }
+}

--- a/Netflixx/Views/Packages/Create.cshtml
+++ b/Netflixx/Views/Packages/Create.cshtml
@@ -1,0 +1,29 @@
+@model Netflixx.Models.PackagesModel
+
+@{
+    ViewData["Title"] = "Create Package";
+}
+
+<div class="container mt-4">
+    <h2 class="text-white mb-3">@ViewData["Title"]</h2>
+
+    <form asp-action="Create">
+        <div asp-validation-summary="ModelOnly" class="text-danger"></div>
+        <div class="mb-3">
+            <label asp-for="Name" class="form-label"></label>
+            <input asp-for="Name" class="form-control" />
+            <span asp-validation-for="Name" class="text-danger"></span>
+        </div>
+        <div class="mb-3">
+            <label asp-for="Description" class="form-label"></label>
+            <textarea asp-for="Description" class="form-control"></textarea>
+            <span asp-validation-for="Description" class="text-danger"></span>
+        </div>
+        <button type="submit" class="btn btn-danger">Create</button>
+        <a asp-action="Index" class="btn btn-outline-light">Back to List</a>
+    </form>
+</div>
+
+@section Scripts {
+    @{ await Html.RenderPartialAsync("_ValidationScriptsPartial"); }
+}

--- a/Netflixx/Views/Packages/Delete.cshtml
+++ b/Netflixx/Views/Packages/Delete.cshtml
@@ -1,0 +1,21 @@
+@model Netflixx.Models.PackagesModel
+
+@{
+    ViewData["Title"] = "Delete Package";
+}
+
+<div class="container mt-4">
+    <h2 class="text-white mb-3">@ViewData["Title"]</h2>
+
+    <h3 class="text-warning">Are you sure you want to delete this package?</h3>
+    <div class="mb-3">
+        <h4>@Model.Name</h4>
+        <p>@Model.Description</p>
+    </div>
+
+    <form asp-action="Delete">
+        <input type="hidden" asp-for="Id" />
+        <button type="submit" class="btn btn-danger">Delete</button>
+        <a asp-action="Index" class="btn btn-outline-light">Cancel</a>
+    </form>
+</div>

--- a/Netflixx/Views/Packages/Edit.cshtml
+++ b/Netflixx/Views/Packages/Edit.cshtml
@@ -1,0 +1,30 @@
+@model Netflixx.Models.PackagesModel
+
+@{
+    ViewData["Title"] = "Edit Package";
+}
+
+<div class="container mt-4">
+    <h2 class="text-white mb-3">@ViewData["Title"]</h2>
+
+    <form asp-action="Edit">
+        <div asp-validation-summary="ModelOnly" class="text-danger"></div>
+        <input type="hidden" asp-for="Id" />
+        <div class="mb-3">
+            <label asp-for="Name" class="form-label"></label>
+            <input asp-for="Name" class="form-control" />
+            <span asp-validation-for="Name" class="text-danger"></span>
+        </div>
+        <div class="mb-3">
+            <label asp-for="Description" class="form-label"></label>
+            <textarea asp-for="Description" class="form-control"></textarea>
+            <span asp-validation-for="Description" class="text-danger"></span>
+        </div>
+        <button type="submit" class="btn btn-danger">Save</button>
+        <a asp-action="Index" class="btn btn-outline-light">Back to List</a>
+    </form>
+</div>
+
+@section Scripts {
+    @{ await Html.RenderPartialAsync("_ValidationScriptsPartial"); }
+}

--- a/Netflixx/Views/Packages/Index.cshtml
+++ b/Netflixx/Views/Packages/Index.cshtml
@@ -1,0 +1,34 @@
+@model IEnumerable<Netflixx.Models.PackagesModel>
+
+@{
+    ViewData["Title"] = "Packages";
+}
+
+<div class="container mt-4">
+    <h2 class="text-white mb-3">Packages</h2>
+    <p>
+        <a asp-action="Create" class="btn btn-danger">Create New</a>
+    </p>
+    <table class="table table-dark table-striped">
+        <thead>
+            <tr>
+                <th>Name</th>
+                <th>Description</th>
+                <th></th>
+            </tr>
+        </thead>
+        <tbody>
+        @foreach (var item in Model)
+        {
+            <tr>
+                <td>@item.Name</td>
+                <td>@item.Description</td>
+                <td>
+                    <a asp-action="Edit" asp-route-id="@item.Id" class="btn btn-sm btn-outline-light me-2">Edit</a>
+                    <a asp-action="Delete" asp-route-id="@item.Id" class="btn btn-sm btn-outline-danger">Delete</a>
+                </td>
+            </tr>
+        }
+        </tbody>
+    </table>
+</div>


### PR DESCRIPTION
## Summary
- implement `PackagesController` for CRUD operations
- add basic create/edit/delete views
- show packages in a simple index table
- update `.gitignore` to include MVC `Packages` views

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685776579e2483278d6c9f354a2544e4