### PR TITLE
Fix MoMo payment for packages

### DIFF
--- a/Netflixx/Controllers/PaymentController.cs
+++ b/Netflixx/Controllers/PaymentController.cs
@@ -1,23 +1,47 @@
-﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
 using Netflixx.Models;
+using Netflixx.Repositories;
 using Netflixx.Services.Momo;
 
 namespace Netflixx.Controllers
 {
     public class PaymentController : Controller
     {
-        private IMomoService _momoService;
+        private readonly IMomoService _momoService;
+        private readonly DBContext _context;
+        private readonly UserManager<AppUserModel> _userManager;
         private readonly IVnPayService _vnPayService;
-        public PaymentController(IMomoService momoService)
+
+        public PaymentController(IMomoService momoService, DBContext context, UserManager<AppUserModel> userManager)
         {
             _momoService = momoService;
+            _context = context;
+            _userManager = userManager;
 
         }
         [HttpPost]
+        [Authorize]
         [Route("CreatePaymentUrl")]
-        public async Task<IActionResult> CreatePaymentUrl(OrderInfoModel model)
+        public async Task<IActionResult> CreatePaymentUrl(int id)
         {
-            var response = await _momoService.CreatePaymentMomo(model);
+            var package = await _context.Packages.FindAsync(id);
+            if (package == null)
+            {
+                return NotFound();
+            }
+
+            var user = await _userManager.GetUserAsync(User);
+            var order = new OrderInfoModel
+            {
+                FullName = user?.FullName ?? user?.UserName ?? string.Empty,
+                OrderInformation = $"Thanh toan goi {package.Name}",
+                Amount = package.Price.ToString("0")
+            };
+
+            var response = await _momoService.CreatePaymentMomo(order);
             return Redirect(response.PayUrl);
         }
         [HttpGet]

--- a/Netflixx/Services/Momo/IMomoService.cs
+++ b/Netflixx/Services/Momo/IMomoService.cs
@@ -1,4 +1,5 @@
-﻿using Netflixx.Models;
+using Microsoft.AspNetCore.Http;
+using Netflixx.Models;
 using Netflixx.Models.Momo;
 
 namespace Netflixx.Services.Momo
@@ -6,6 +7,6 @@ namespace Netflixx.Services.Momo
     public interface IMomoService
     {
         Task<MomoCreatePaymentResponseModel> CreatePaymentMomo(OrderInfoModel request);
-        MomoExecuteResponseModel MomoExecuteResponseModel(IQueryCollection collection);
+        MomoExecuteResponseModel PaymentExecuteAsync(IQueryCollection collection);
     }
 }

--- a/Netflixx/Services/Momo/MomoService.cs
+++ b/Netflixx/Services/Momo/MomoService.cs
@@ -1,9 +1,11 @@
-﻿using System.Security.Cryptography;
+using System.Security.Cryptography;
 using System.Text;
 using Microsoft.Extensions.Options;
+using Microsoft.AspNetCore.Http;
 using Netflixx.Models;
 using Netflixx.Models.Momo;
 using Newtonsoft.Json;
+using RestSharp;
 
 namespace Netflixx.Services.Momo
 {
@@ -14,7 +16,7 @@ namespace Netflixx.Services.Momo
         {
             _options = options;
         }
-        public async Task<MomoCreatePaymentResponseModel> CreatePaymentAsync(OrderInfoModel model)
+        public async Task<MomoCreatePaymentResponseModel> CreatePaymentMomo(OrderInfoModel model)
         {
             model.OrderId = DateTime.UtcNow.Ticks.ToString();
             model.OrderInformation = "Khách hàng: " + model.FullName + ". Nội dung: " + model.OrderInformation;

--- a/Netflixx/Views/Packages/List.cshtml
+++ b/Netflixx/Views/Packages/List.cshtml
@@ -24,7 +24,7 @@
                 <td>@item.Description</td>
                 <td>@string.Format("{0:C}", item.Price)</td>
                 <td>
-                    <form asp-action="CreatePaymentMomo" method="post" asp-controller="Payment">
+                    <form asp-action="CreatePaymentUrl" method="post" asp-controller="Payment">
                         <input type="hidden" name="id" value="@item.Id" />
                         <button type="submit" class="btn btn-danger">Pay with MoMo</button>
                     </form>

--- a/Netflixx/Views/Payment/PaymentCallBack.cshtml
+++ b/Netflixx/Views/Payment/PaymentCallBack.cshtml
@@ -1,0 +1,13 @@
+@model Netflixx.Models.Momo.MomoExecuteResponseModel
+@{
+    ViewData["Title"] = "Payment Result";
+}
+<div class="container mt-4">
+    <h2 class="text-white mb-3">Payment Result</h2>
+    <table class="table table-dark table-striped">
+        <tr><th>Order ID</th><td>@Model.OrderId</td></tr>
+        <tr><th>Amount</th><td>@Model.Amount</td></tr>
+        <tr><th>Information</th><td>@Model.OrderInfo</td></tr>
+    </table>
+    <a asp-controller="Packages" asp-action="List" class="btn btn-danger">Back to Packages</a>
+</div>


### PR DESCRIPTION
## Summary
- link packages page to payment API
- wire up DB context and user manager for generating MoMo orders
- align `IMomoService` interface with `MomoService` implementation
- expose a simple payment callback view

## Testing
- `npm run scss` *(fails: sass not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857ba1f2548832792b950ffed612d29