### PR TITLE
Fix MoMo payment request signature

### DIFF
--- a/Netflixx/Services/Momo/MomoService.cs
+++ b/Netflixx/Services/Momo/MomoService.cs
@@ -29,7 +29,8 @@ namespace Netflixx.Services.Momo
                 $"&orderInfo={model.OrderInformation}" +
                 $"&returnUrl={_options.Value.ReturnUrl}" +
                 $"&notifyUrl={_options.Value.NotifyUrl}" +
-                $"&extraData=";
+                $"&extraData=" +
+                $"&requestType={_options.Value.RequestType}";
 
             var signature = ComputeHmacSha256(rawData, _options.Value.SecretKey);
 

--- a/Netflixx/appsettings.json
+++ b/Netflixx/appsettings.json
@@ -22,7 +22,7 @@
         "MomoApiUrl": "https://test-payment.momo.vn/gw_payment/transactionProcessor",
         "SecretKey": "K951B6PE1waDMi640xX08PD3vg6EkVlz",
         "AccessKey": "F8BBA842ECF85",
-        "ReturnUrl": "http://localhost:5172/Checkout/PaymentCallBack",
+        "ReturnUrl": "http://localhost:5172/Payment/PaymentCallBack",
         "NotifyUrl": "http://localhost:5172/Checkout/MomoNotify",
         "PartnerCode": "MOMO",
         "RequestType": "captureMoMoWallet" //payWithATM //captureMoMoWallet


### PR DESCRIPTION
## Summary
- include `requestType` parameter when computing MoMo payment signature
- fix return URL path for MoMo callback

## Testing
- `npm run scss` *(fails: `sass` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857bd0a07688327b09a801149b6c1eb