### PR TITLE
Fix missing RestSharp dependency

### DIFF
--- a/Netflixx/Netflixx.csproj
+++ b/Netflixx/Netflixx.csproj
@@ -22,6 +22,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="RestSharp" Version="110.2.0" />
   </ItemGroup>
 
 


### PR DESCRIPTION
## Summary
- add RestSharp package so `MomoService` compiles

## Testing
- `dotnet build Netflixx/Netflixx.csproj -nologo`
- `npm run scss` *(fails: `sass: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6857bf8d58188327b229b25b7017e2a1