### PR TITLE
Fix Momo payment route

### DIFF
--- a/Netflixx/Controllers/PaymentController.cs
+++ b/Netflixx/Controllers/PaymentController.cs
@@ -24,7 +24,6 @@ namespace Netflixx.Controllers
         }
         [HttpPost]
         [Authorize]
-        [Route("CreatePaymentUrl")]
         public async Task<IActionResult> CreatePaymentUrl(int id)
         {
             var package = await _context.Packages.FindAsync(id);


### PR DESCRIPTION
## Summary
- fix MoMo payment route on `CreatePaymentUrl`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6857c1b35d4483278abe03afea6ab666