### PR TITLE
Fix login redirect path

### DIFF
--- a/Netflixx/Program.cs
+++ b/Netflixx/Program.cs
@@ -57,6 +57,8 @@ namespace Netflixx
                 // Cookie tạm thời (cho phiên làm việc) nếu RememberMe = false
                 options.ExpireTimeSpan = TimeSpan.FromDays(30); // Thời gian tồn tại khi RememberMe = true
                 options.SlidingExpiration = true; // Reset thời gian tồn tại khi user hoạt động
+                // Đặt đường dẫn trang đăng nhập mặc định
+                options.LoginPath = "/Login/Login";
             });
 
 


### PR DESCRIPTION
## Summary
- configure cookie options to use `/Login/Login` as the login page

## Testing
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857c47b9710832794773dd1d8225566