### PR TITLE
Add Google transaction import

### DIFF
--- a/Netflixx/Controllers/GoogleTransactionsController.cs
+++ b/Netflixx/Controllers/GoogleTransactionsController.cs
@@ -1,0 +1,29 @@
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Netflixx.Models;
+using Netflixx.Repositories;
+using Netflixx.Services;
+
+namespace Netflixx.Controllers
+{
+    public class GoogleTransactionsController : Controller
+    {
+        private readonly DBContext _context;
+        private readonly IGoogleTransactionService _service;
+
+        public GoogleTransactionsController(DBContext context, IGoogleTransactionService service)
+        {
+            _context = context;
+            _service = service;
+        }
+
+        [HttpPost]
+        public async Task<IActionResult> Import()
+        {
+            var transactions = await _service.FetchTransactionsAsync();
+            _context.GoogleTransactions.AddRange(transactions);
+            await _context.SaveChangesAsync();
+            return Ok(new { imported = transactions.Count });
+        }
+    }
+}

--- a/Netflixx/Models/GoogleTransactionModel.cs
+++ b/Netflixx/Models/GoogleTransactionModel.cs
@@ -1,0 +1,29 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using System.Text.Json.Serialization;
+
+namespace Netflixx.Models
+{
+    public class GoogleTransactionModel
+    {
+        [Key]
+        [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+        public int Id { get; set; }
+
+        [JsonPropertyName("Mã GD")]
+        public long TransactionCode { get; set; }
+
+        [JsonPropertyName("Mô tả")]
+        public string Description { get; set; }
+
+        [JsonPropertyName("Giá trị")]
+        public decimal Amount { get; set; }
+
+        [JsonPropertyName("Ngày diễn ra")]
+        public DateTime TransactionDate { get; set; }
+
+        [JsonPropertyName("Số tài khoản")]
+        public string AccountNumber { get; set; }
+    }
+}

--- a/Netflixx/Program.cs
+++ b/Netflixx/Program.cs
@@ -23,6 +23,8 @@ namespace Netflixx
 
             builder.Services.AddSingleton<IOtpGenerator, SecureOtpGenerator>();
 
+            builder.Services.AddHttpClient<IGoogleTransactionService, GoogleTransactionService>();
+
             // Add services to the container.
             builder.Services.AddControllersWithViews();
 

--- a/Netflixx/Repositories/DBContext.cs
+++ b/Netflixx/Repositories/DBContext.cs
@@ -40,6 +40,7 @@ namespace Netflixx.Repositories
         public virtual DbSet<PackageSubscriptionUpgradesModel> PackageSubscriptionUpgrades { get; set; }
         public virtual DbSet<UserAccountsModel> UserAccounts { get; set; }
         public virtual DbSet<PointsTransactionsModel> PointsTransactions { get; set; }
+        public virtual DbSet<GoogleTransactionModel> GoogleTransactions { get; set; }
         public virtual DbSet<DailyRevenueModel> DailyRevenue { get; set; }
         public virtual DbSet<ProductionManager> ProductionManagers { get; set; }
         public virtual DbSet<ProductionManagerHistory> ProductionManagerHistories { get; set; }
@@ -146,6 +147,10 @@ namespace Netflixx.Repositories
 
             modelBuilder.Entity<UserAccountsModel>()
                 .Property(u => u.Balance)
+                .HasPrecision(18, 2);
+
+            modelBuilder.Entity<GoogleTransactionModel>()
+                .Property(g => g.Amount)
                 .HasPrecision(18, 2);
 
             // Configure many-to-many relationships

--- a/Netflixx/Services/GoogleTransactionService.cs
+++ b/Netflixx/Services/GoogleTransactionService.cs
@@ -1,0 +1,34 @@
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Netflixx.Models;
+
+namespace Netflixx.Services
+{
+    public class GoogleTransactionService : IGoogleTransactionService
+    {
+        private readonly HttpClient _httpClient;
+        private const string Url = "https://script.google.com/macros/s/AKfycbyi5nMWfuHp3BigdOV9h0lq97ci0f1YTWOlULUsRgkW8_AT0e34FVu67ao3l00EXOHx/exec";
+
+        public GoogleTransactionService(HttpClient httpClient)
+        {
+            _httpClient = httpClient;
+        }
+
+        public async Task<List<GoogleTransactionModel>> FetchTransactionsAsync()
+        {
+            using var response = await _httpClient.GetAsync(Url);
+            response.EnsureSuccessStatusCode();
+            var content = await response.Content.ReadAsStringAsync();
+            var wrapper = JsonSerializer.Deserialize<GoogleTransactionWrapper>(content);
+            return wrapper?.Data ?? new List<GoogleTransactionModel>();
+        }
+
+        private class GoogleTransactionWrapper
+        {
+            public List<GoogleTransactionModel> Data { get; set; }
+            public bool Error { get; set; }
+        }
+    }
+}

--- a/Netflixx/Services/IGoogleTransactionService.cs
+++ b/Netflixx/Services/IGoogleTransactionService.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Netflixx.Models;
+
+namespace Netflixx.Services
+{
+    public interface IGoogleTransactionService
+    {
+        Task<List<GoogleTransactionModel>> FetchTransactionsAsync();
+    }
+}


### PR DESCRIPTION
## Summary
- model to store Google script data
- service and controller to import Google transactions
- register service and DBSet

## Testing
- `npm run scss` *(fails: sass not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858146b5c1483279490888e6d75b522