### PR TITLE
Add Google script payment import

### DIFF
--- a/Netflixx/Controllers/PaymentTransactionsController.cs
+++ b/Netflixx/Controllers/PaymentTransactionsController.cs
@@ -1,0 +1,86 @@
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Netflixx.Models;
+using Netflixx.Models.Binding;
+using Netflixx.Repositories;
+using System.Text.Json;
+
+namespace Netflixx.Controllers
+{
+    public class PaymentTransactionsController : Controller
+    {
+        private readonly DBContext _db;
+        private readonly UserManager<AppUserModel> _userManager;
+
+        public PaymentTransactionsController(DBContext db, UserManager<AppUserModel> userManager)
+        {
+            _db = db;
+            _userManager = userManager;
+        }
+
+        [HttpPost]
+        public async Task<IActionResult> ImportFromGoogle()
+        {
+            var url = "https://script.google.com/macros/s/AKfycbyi5nMWfuHp3BigdOV9h0lq97ci0f1YTWOlULUsRgkW8_AT0e34FVu67ao3l00EXOHx/exec";
+            using var client = new HttpClient();
+            var json = await client.GetStringAsync(url);
+            var options = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
+            var response = JsonSerializer.Deserialize<ExternalTransactionResponse>(json, options);
+            if (response?.Data == null)
+            {
+                return BadRequest("No data received");
+            }
+
+            var provider = await _db.PaymentProviders.FirstOrDefaultAsync();
+            if (provider == null)
+            {
+                provider = new PaymentProvidersModel { Name = "Default Provider" };
+                _db.PaymentProviders.Add(provider);
+                await _db.SaveChangesAsync();
+            }
+
+            var environment = await _db.PaymentEnvironments.FirstOrDefaultAsync();
+            if (environment == null)
+            {
+                environment = new PaymentEnvironmentsModel { Name = "Default Environment" };
+                _db.PaymentEnvironments.Add(environment);
+                await _db.SaveChangesAsync();
+            }
+
+            var user = await _userManager.Users.FirstOrDefaultAsync();
+            if (user == null)
+            {
+                var newUser = new AppUserModel { UserName = "imported", Email = "import@example.com" };
+                await _userManager.CreateAsync(newUser, "Password@123");
+                user = newUser;
+            }
+
+            foreach (var item in response.Data)
+            {
+                if (!DateTime.TryParse(item.TransactionDate, out var date))
+                {
+                    continue;
+                }
+
+                var transaction = new PaymentTransactionsModel
+                {
+                    UserID = user.Id,
+                    ProviderID = provider.ProviderID,
+                    EnvironmentID = environment.EnvironmentID,
+                    TransactionDate = date,
+                    Amount = item.Amount,
+                    Currency = "VND",
+                    Status = "Success",
+                    ExternalTransactionRef = item.TransactionCode.ToString(),
+                    SecretToken = Guid.NewGuid().ToString()
+                };
+
+                _db.PaymentTransactions.Add(transaction);
+            }
+
+            var inserted = await _db.SaveChangesAsync();
+            return Ok(new { inserted });
+        }
+    }
+}

--- a/Netflixx/Models/Binding/ExternalTransactionDto.cs
+++ b/Netflixx/Models/Binding/ExternalTransactionDto.cs
@@ -1,0 +1,31 @@
+using System.Text.Json.Serialization;
+
+namespace Netflixx.Models.Binding
+{
+    public class ExternalTransactionDto
+    {
+        [JsonPropertyName("Mã GD")]
+        public int TransactionCode { get; set; }
+
+        [JsonPropertyName("Mô tả")]
+        public string? Description { get; set; }
+
+        [JsonPropertyName("Giá trị")]
+        public decimal Amount { get; set; }
+
+        [JsonPropertyName("Ngày diễn ra")]
+        public string? TransactionDate { get; set; }
+
+        [JsonPropertyName("Số tài khoản")]
+        public string? AccountNumber { get; set; }
+    }
+
+    public class ExternalTransactionResponse
+    {
+        [JsonPropertyName("data")]
+        public List<ExternalTransactionDto>? Data { get; set; }
+
+        [JsonPropertyName("error")]
+        public bool Error { get; set; }
+    }
+}


### PR DESCRIPTION
## Summary
- add data transfer objects for Google Script responses
- add PaymentTransactionsController to import JSON data from Google script URL into the PaymentTransactions table

## Testing
- `dotnet build Netflixx/Netflixx.csproj -nologo`

------
https://chatgpt.com/codex/tasks/task_e_685819e43dc483278ae159e4d82b891d