### PR TITLE
Fix nullable ProductionManagerId

### DIFF
--- a/Netflixx/Controllers/FilmController1.cs
+++ b/Netflixx/Controllers/FilmController1.cs
@@ -232,7 +232,7 @@ namespace Netflixx.Controllers
                 }
 
                 // 2. Kiểm tra ProductionManagerId (bắt buộc)
-                if (film.ProductionManagerId <= 0)
+                if (!film.ProductionManagerId.HasValue || film.ProductionManagerId <= 0)
                 {
                     ModelState.AddModelError("ProductionManagerId", "Vui lòng chọn quản lý sản xuất");
                 }
@@ -377,7 +377,7 @@ namespace Netflixx.Controllers
                 film.FilmURL = updatedFilm.FilmURL;
 
                 // Chỉ cập nhật ProductionManagerId nếu có giá trị hợp lệ
-                if (updatedFilm.ProductionManagerId > 0)
+                if (updatedFilm.ProductionManagerId.HasValue && updatedFilm.ProductionManagerId > 0)
                 {
                     film.ProductionManagerId = updatedFilm.ProductionManagerId;
                 }

--- a/Netflixx/Migrations/20250629085013_db1.Designer.cs
+++ b/Netflixx/Migrations/20250629085013_db1.Designer.cs
@@ -625,7 +625,7 @@ namespace Netflixx.Migrations
                         .HasPrecision(18, 2)
                         .HasColumnType("decimal(18,2)");
 
-                    b.Property<int>("ProductionManagerId")
+                    b.Property<int?>("ProductionManagerId")
                         .HasColumnType("int");
 
                     b.Property<float?>("Rating")
@@ -1496,7 +1496,7 @@ namespace Netflixx.Migrations
                         .WithMany("Films")
                         .HasForeignKey("ProductionManagerId")
                         .OnDelete(DeleteBehavior.SetNull)
-                        .IsRequired();
+                        .IsRequired(false);
 
                     b.Navigation("ProductionManager");
                 });

--- a/Netflixx/Migrations/20250629085013_db1.cs
+++ b/Netflixx/Migrations/20250629085013_db1.cs
@@ -531,7 +531,7 @@ namespace Netflixx.Migrations
                     Description = table.Column<string>(type: "nvarchar(max)", nullable: true),
                     Price = table.Column<decimal>(type: "decimal(18,2)", precision: 18, scale: 2, nullable: true),
                     PosterPath = table.Column<string>(type: "nvarchar(max)", nullable: true),
-                    ProductionManagerId = table.Column<int>(type: "int", nullable: false),
+                    ProductionManagerId = table.Column<int>(type: "int", nullable: true),
                     TrailerURL = table.Column<string>(type: "nvarchar(max)", nullable: true),
                     Rating = table.Column<float>(type: "real", nullable: true),
                     Duration = table.Column<int>(type: "int", nullable: true),

--- a/Netflixx/Migrations/DBContextModelSnapshot.cs
+++ b/Netflixx/Migrations/DBContextModelSnapshot.cs
@@ -622,7 +622,7 @@ namespace Netflixx.Migrations
                         .HasPrecision(18, 2)
                         .HasColumnType("decimal(18,2)");
 
-                    b.Property<int>("ProductionManagerId")
+                    b.Property<int?>("ProductionManagerId")
                         .HasColumnType("int");
 
                     b.Property<float?>("Rating")
@@ -1493,7 +1493,7 @@ namespace Netflixx.Migrations
                         .WithMany("Films")
                         .HasForeignKey("ProductionManagerId")
                         .OnDelete(DeleteBehavior.SetNull)
-                        .IsRequired();
+                        .IsRequired(false);
 
                     b.Navigation("ProductionManager");
                 });

--- a/Netflixx/Models/FilmsModel.cs
+++ b/Netflixx/Models/FilmsModel.cs
@@ -34,9 +34,8 @@ namespace Netflixx.Models
 
         public string? PosterPath { get; set; }
 
-        [Required(ErrorMessage = "Quản lý sản xuất là bắt buộc")]
         [Display(Name = "Quản lý sản xuất")]
-        public int ProductionManagerId { get; set; }  // Bắt buộc (không nullable)
+        public int? ProductionManagerId { get; set; }
 
         [ForeignKey("ProductionManagerId")]  // Áp dụng vào Navigation Property
         public virtual ProductionManager? ProductionManager { get; set; }


### PR DESCRIPTION
## Summary
- make `ProductionManagerId` nullable for `FilmsModel`
- adjust controllers for nullable ID
- update initial migration and snapshots accordingly

## Testing
- `dotnet build Netflixx.sln`
- `npm run scss` *(fails: Can't find stylesheet)*

------
https://chatgpt.com/codex/tasks/task_e_6860fe7079688327a45ac5833e459f7c