### PR TITLE
Add VNPay recharge integration

### DIFF
--- a/Netflixx/Controllers/PaymentController.cs
+++ b/Netflixx/Controllers/PaymentController.cs
@@ -1,0 +1,95 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Netflixx.Models;
+using Netflixx.Models.Vnpay;
+using Netflixx.Repositories;
+using Netflixx.Services.Vnpay;
+
+namespace Netflixx.Controllers
+{
+    [Authorize]
+    public class PaymentController : Controller
+    {
+        private readonly IVnPayService _vnPayService;
+        private readonly UserManager<AppUserModel> _userManager;
+        private readonly DBContext _context;
+
+        public PaymentController(IVnPayService vnPayService,
+                                 UserManager<AppUserModel> userManager,
+                                 DBContext context)
+        {
+            _vnPayService = vnPayService;
+            _userManager = userManager;
+            _context = context;
+        }
+
+        [HttpGet]
+        public IActionResult Recharge()
+        {
+            return View();
+        }
+
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        public IActionResult Recharge(decimal amount)
+        {
+            if (amount <= 0)
+            {
+                ModelState.AddModelError(string.Empty, "Amount must be greater than 0");
+                return View();
+            }
+
+            var paymentModel = new PaymentInformationModel
+            {
+                Amount = (double)amount,
+                OrderDescription = "Recharge coins",
+                OrderType = "deposit",
+                Name = User.Identity?.Name ?? "User"
+            };
+
+            var paymentUrl = _vnPayService.CreatePaymentUrl(paymentModel, HttpContext);
+            return Redirect(paymentUrl);
+        }
+
+        [HttpGet]
+        public async Task<IActionResult> PaymentCallbackVnpay()
+        {
+            var response = _vnPayService.PaymentExecute(Request.Query);
+            var success = response.Success && response.VnPayResponseCode == "00";
+
+            if (success)
+            {
+                var amountStr = Request.Query["vnp_Amount"].FirstOrDefault();
+                var user = await _userManager.GetUserAsync(User);
+                if (user != null && long.TryParse(amountStr, out var amount))
+                {
+                    var coins = (int)(amount / 100);
+                    var account = await _context.UserAccounts.FirstOrDefaultAsync(a => a.UserID == user.Id);
+                    if (account == null)
+                    {
+                        account = new UserAccountsModel
+                        {
+                            UserID = user.Id,
+                            Balance = 0,
+                            PointsBalance = 0
+                        };
+                        _context.UserAccounts.Add(account);
+                    }
+                    account.PointsBalance += coins;
+                    _context.PointsTransactions.Add(new PointsTransactionsModel
+                    {
+                        UserID = user.Id,
+                        TransactionDate = DateTime.UtcNow,
+                        PointsChange = coins,
+                        Reason = "Recharge via VNPAY"
+                    });
+                    await _context.SaveChangesAsync();
+                }
+            }
+
+            return View("RechargeResult", success);
+        }
+    }
+}

--- a/Netflixx/Libraries/VnPayLibrary.cs
+++ b/Netflixx/Libraries/VnPayLibrary.cs
@@ -179,4 +179,3 @@ namespace Netflixx.Libraries
     }
 
 }
-}

--- a/Netflixx/Views/Payment/Recharge.cshtml
+++ b/Netflixx/Views/Payment/Recharge.cshtml
@@ -1,0 +1,11 @@
+@{
+    ViewData["Title"] = "Recharge";
+}
+<h2>Recharge Coins</h2>
+<form asp-action="Recharge" method="post">
+    <div class="mb-3">
+        <label for="amount" class="form-label">Amount (VND)</label>
+        <input type="number" class="form-control" id="amount" name="amount" required min="1" />
+    </div>
+    <button type="submit" class="btn btn-primary">Pay with VNPAY</button>
+</form>

--- a/Netflixx/Views/Payment/RechargeResult.cshtml
+++ b/Netflixx/Views/Payment/RechargeResult.cshtml
@@ -1,0 +1,13 @@
+@model bool
+@{
+    ViewData["Title"] = "Recharge Result";
+}
+@if (Model)
+{
+    <div class="alert alert-success">Recharge successful!</div>
+}
+else
+{
+    <div class="alert alert-danger">Recharge failed!</div>
+}
+<a asp-action="Recharge" class="btn btn-secondary">Back</a>

--- a/Netflixx/Views/Shared/_Layout.cshtml
+++ b/Netflixx/Views/Shared/_Layout.cshtml
@@ -49,6 +49,7 @@
                         <li><a class="dropdown-item" asp-controller="Home" asp-action="Profile">Profile</a></li>
                         <li><a class="dropdown-item" asp-controller="Home" asp-action="History">History</a></li>
                         <li><a class="dropdown-item" asp-controller="Home" asp-action="MyList">My List</a></li>
+                        <li><a class="dropdown-item" asp-controller="Payment" asp-action="Recharge">Recharge</a></li>
                         <li><button class="dropdown-item" type="button">Settings</button></li>
                         <li><hr class="dropdown-divider" /></li>
                         <li>

--- a/Netflixx/appsettings.json
+++ b/Netflixx/appsettings.json
@@ -26,7 +26,7 @@
         "CurrCode": "VND",
         "Version": "2.1.0",
         "Locale": "vn",
-        "PaymentBackReturnUrl": "http://localhost:5172/Checkout/PaymentCallbackVnpay"
+        "PaymentBackReturnUrl": "http://localhost:5172/Payment/PaymentCallbackVnpay"
     },
 
 


### PR DESCRIPTION
## Summary
- integrate VNPay payments for topping up coins
- add Payment controller with recharge view and callback handling
- expose Recharge link in layout
- update VNPay return URL configuration
- fix extra closing brace in VnPayLibrary

## Testing
- `dotnet build Netflixx.sln`

------
https://chatgpt.com/codex/tasks/task_e_6874a843d7b8832693499d303674dd47