### PR TITLE
Fix VNPay callback config and timezone

### DIFF
--- a/Netflixx/Services/Vnpay/VnPayService.cs
+++ b/Netflixx/Services/Vnpay/VnPayService.cs
@@ -12,11 +12,14 @@ namespace Netflixx.Services.Vnpay
         }
         public string CreatePaymentUrl(PaymentInformationModel model, HttpContext context)
         {
-            var timeZoneById = TimeZoneInfo.FindSystemTimeZoneById(_configuration["TimeZoneId"]);
+            var timeZoneId = _configuration["TimeZoneId"];
+            var timeZoneById = string.IsNullOrEmpty(timeZoneId)
+                ? TimeZoneInfo.Local
+                : TimeZoneInfo.FindSystemTimeZoneById(timeZoneId);
             var timeNow = TimeZoneInfo.ConvertTimeFromUtc(DateTime.UtcNow, timeZoneById);
             var tick = DateTime.Now.Ticks.ToString();
             var pay = new VnPayLibrary();
-            var urlCallBack = _configuration["PaymentCallBack:ReturnUrl"];
+            var urlCallBack = _configuration["Vnpay:PaymentBackReturnUrl"];
 
             pay.AddRequestData("vnp_Version", _configuration["Vnpay:Version"]);
             pay.AddRequestData("vnp_Command", _configuration["Vnpay:Command"]);

--- a/Netflixx/appsettings.json
+++ b/Netflixx/appsettings.json
@@ -18,6 +18,7 @@
     "ConnectionStrings": {
         "DefaultConnection": "Server=(local);Database=Netflixx;User Id=sa;Password=sa123;TrustServerCertificate=true;"
     },
+    "TimeZoneId": "SE Asia Standard Time",
     "Vnpay": {
         "TmnCode": "4NF6MQLG",
         "HashSecret": "SNM7HUAM78A66DTKAK043E893H2DJ462",


### PR DESCRIPTION
## Summary
- fix VNPay service config key for return URL
- add fallback timezone logic
- define `TimeZoneId` in appsettings

## Testing
- `npm install`
- `npm run scss` *(fails: Can't find stylesheet to import)*

------
https://chatgpt.com/codex/tasks/task_e_6874ad54654c8326946edcd1da5dff7d