### PR TITLE
Fix VNPAY return URL

### DIFF
--- a/Netflixx/Services/Vnpay/VnPayService.cs
+++ b/Netflixx/Services/Vnpay/VnPayService.cs
@@ -20,6 +20,10 @@ namespace Netflixx.Services.Vnpay
             var tick = DateTime.Now.Ticks.ToString();
             var pay = new VnPayLibrary();
             var urlCallBack = _configuration["Vnpay:PaymentBackReturnUrl"];
+            if (string.IsNullOrWhiteSpace(urlCallBack))
+            {
+                urlCallBack = $"{context.Request.Scheme}://{context.Request.Host}/Payment/PaymentCallbackVnpay";
+            }
 
             pay.AddRequestData("vnp_Version", _configuration["Vnpay:Version"]);
             pay.AddRequestData("vnp_Command", _configuration["Vnpay:Command"]);

--- a/Netflixx/appsettings.json
+++ b/Netflixx/appsettings.json
@@ -27,7 +27,7 @@
         "CurrCode": "VND",
         "Version": "2.1.0",
         "Locale": "vn",
-        "PaymentBackReturnUrl": "http://localhost:5172/Payment/PaymentCallbackVnpay"
+        "PaymentBackReturnUrl": "https://localhost:7198/Payment/PaymentCallbackVnpay"
     },
 
 


### PR DESCRIPTION
## Summary
- fix payment callback URL when config value missing
- correct default VNPAY callback in `appsettings.json`

## Testing
- `dotnet build Netflixx.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_6874b179974c8326bcddb9c60bf91f96