### PR TITLE
Synchronize header styling

### DIFF
--- a/Netflixx/Views/Film/Detail.cshtml
+++ b/Netflixx/Views/Film/Detail.cshtml
@@ -25,6 +25,7 @@
 <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@200;300;400;500;600;700;800;900&display=swap" rel="stylesheet" />
 <link href="~/lib/bootstrap/dist/css/bootstrap.min.css" rel="stylesheet" />
 <link href="~/css/fontawesome.css" rel="stylesheet" />
+<link rel="stylesheet" href="~/css/homepage.css" />
 
 <style>
     body {
@@ -122,48 +123,7 @@
 </style>
 
 <header>
-    <nav class="navbar navbar-expand-lg navbar-dark bg-dark fixed-top">
-
-        <div class="container-fluid">
-            <a class="navbar-brand" asp-area="" asp-controller="Home" asp-action="Index">
-                <img src="/image/logo/NetflixxLogo.png"
-                     alt="Netflixx Logo"
-                     style="height:40px;" />
-            </a>
-            <ul class="navbar-nav me-auto">
-                <li class="nav-item"><a class="nav-link active" asp-controller="Home" asp-action="Index">Home</a></li>
-                <li class="nav-item"><a class="nav-link" asp-controller="Film" asp-action="Index">Search</a></li>
-                <li class="nav-item"><a class="nav-link" asp-controller="Film" asp-action="Type">Films</a></li>
-                <li class="nav-item"><a class="nav-link" asp-controller="Filmpackage" asp-action="Index">Film Package</a></li>
-                <li class="nav-item"><a class="nav-link" asp-controller="Blog" asp-action="Index">Blog</a></li>
-                <li class="nav-item"><a class="nav-link" asp-area="ShopSouvenir" asp-controller="Home" asp-action="Index">Souvenir</a></li>
-                <li class="nav-item"><a class="nav-link" asp-area="ProductionManager" asp-controller="ProductionManager" asp-action="Index">List Company</a></li>
-                <li class="nav-item"><a class="nav-link" href="#">Series</a></li>
-                <li class="nav-item"><a class="nav-link" href="#">Categories</a></li>
-            </ul>
-            <span class="navbar-text me-3"><i class="fa fa-bell"></i></span>
-            <div class="dropdown">
-                <a class="nav-link dropdown-toggle p-0" role="button"
-                   id="avatarDropdown" data-bs-toggle="dropdown" aria-expanded="false">
-                    <img src="@ViewBag.AvatarUrl"
-                         class="avatar-trigger"
-                         alt="User avatar" />
-                </a>
-                <ul class="dropdown-menu dropdown-menu-end mt-2" aria-labelledby="avatarDropdown">
-                    <li><a class="dropdown-item" asp-controller="Home" asp-action="Profile">Profile</a></li>
-                    <li><a class="dropdown-item" asp-controller="Home" asp-action="History">History</a></li>
-                    <li><a class="dropdown-item" asp-controller="Home" asp-action="MyList">My List</a></li>
-                    <li><button class="dropdown-item" type="button">Settings</button></li>
-                    <li><hr class="dropdown-divider" /></li>
-                    <li>
-                        <form asp-controller="Logout" asp-action="Logout" method="post" class="m-0">
-                            <button type="submit" class="dropdown-item">Sign out</button>
-                        </form>
-                    </li>
-                </ul>
-            </div>
-        </div>
-    </nav>
+    @await Html.PartialAsync("_HomeMenu")
 </header>
 
 <div class="container py-4" style="margin-top: 69px">

--- a/Netflixx/Views/Film/DetailSreach.cshtml
+++ b/Netflixx/Views/Film/DetailSreach.cshtml
@@ -3,40 +3,6 @@
     ViewData["Title"] = Model.Title;
 }
 
-<!-- Thêm thanh navbar giống Homepage -->
-<nav class="navbar navbar-expand-lg navbar-dark bg-dark fixed-top">
-    <div class="container-fluid">
-        <a class="navbar-brand" href="#">Logo</a>
-        <ul class="navbar-nav me-auto">
-            <li class="nav-item"><a class="nav-link" asp-controller="Home" asp-action="Index">Home</a></li>
-            <li class="nav-item"><a class="nav-link" asp-controller="Film" asp-action="Index">Sreach</a></li>
-            <li class="nav-item"><a class="nav-link" asp-controller="Film" asp-action="Type">Films</a></li>
-            <li class="nav-item"><a class="nav-link" href="#">Series</a></li>
-            <li class="nav-item"><a class="nav-link" href="#">Categories</a></li>
-        </ul>
-        <span class="navbar-text me-3">Noti</span>
-        <div class="dropdown">
-            <a class="nav-link dropdown-toggle p-0" href="#" role="button"
-               id="avatarDropdown" data-bs-toggle="dropdown" aria-expanded="false">
-                <img src="@ViewBag.AvatarUrl"
-                     class="avatar-trigger"
-                     alt="User avatar" />
-            </a>
-            <ul class="dropdown-menu dropdown-menu-end mt-2" aria-labelledby="avatarDropdown">
-                <li><a class="dropdown-item" asp-controller="Home" asp-action="Profile">Profile</a></li>
-                <li><button class="dropdown-item" type="button">Settings</button></li>
-                <li><hr class="dropdown-divider" /></li>
-                <li>
-                    <form asp-controller="Account" asp-action="Logout" method="post" class="m-0">
-                        <button type="submit" class="dropdown-item">Sign out</button>
-                    </form>
-                </li>
-            </ul>
-        </div>
-    </div>
-</nav>
-
-<!-- Thêm padding để nội dung không bị navbar che -->
 <div class="container-fluid main-content" style="padding-top: 70px;">
 
     <link rel="stylesheet" href="~/css/film.css" />

--- a/Netflixx/Views/Film/ManagerFilm/CreateFilms.cshtml
+++ b/Netflixx/Views/Film/ManagerFilm/CreateFilms.cshtml
@@ -14,6 +14,7 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet" />
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" />
     <link rel="stylesheet" href="/css/filmmanager.css" />
+    <link rel="stylesheet" href="~/css/homepage.css" />
     <link rel="stylesheet" href="~/css/film.css" />
 
     <style>

--- a/Netflixx/Views/Film/ManagerFilm/DeletedFilms.cshtml
+++ b/Netflixx/Views/Film/ManagerFilm/DeletedFilms.cshtml
@@ -17,6 +17,7 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" />
     <link rel="stylesheet" href="https://cdn.datatables.net/1.13.4/css/dataTables.bootstrap5.min.css" />
     <link rel="stylesheet" href="/css/filmmanager.css" />
+    <link rel="stylesheet" href="~/css/homepage.css" />
     <link rel="stylesheet" href="~/css/film.css" />
 
     <style>

--- a/Netflixx/Views/Film/ManagerFilm/EditHistory.cshtml
+++ b/Netflixx/Views/Film/ManagerFilm/EditHistory.cshtml
@@ -18,6 +18,7 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" />
     <link rel="stylesheet" href="https://cdn.datatables.net/1.13.4/css/dataTables.bootstrap5.min.css" />
     <link rel="stylesheet" href="/css/filmmanager.css" />
+    <link rel="stylesheet" href="~/css/homepage.css" />
     <link rel="stylesheet" href="~/css/film.css" />
 
     <style>

--- a/Netflixx/Views/Film/ManagerFilm/SearchFilms.cshtml
+++ b/Netflixx/Views/Film/ManagerFilm/SearchFilms.cshtml
@@ -23,6 +23,7 @@
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" />
         <link rel="stylesheet" href="https://cdn.datatables.net/1.13.4/css/dataTables.bootstrap5.min.css" />
         <link rel="stylesheet" href="/css/filmmanager.css" />
+        <link rel="stylesheet" href="~/css/homepage.css" />
         <link rel="stylesheet" href="~/css/film.css" />
 
         <style>

--- a/Netflixx/Views/Film/Type.cshtml
+++ b/Netflixx/Views/Film/Type.cshtml
@@ -2,40 +2,6 @@
     ViewData["Title"] = "Film List";
 }
 
-<!-- Thêm thanh navbar giống Homepage -->
-<nav class="navbar navbar-expand-lg navbar-dark bg-dark fixed-top">
-    <div class="container-fluid">
-        <a class="navbar-brand" href="#">Logo</a>
-        <ul class="navbar-nav me-auto">
-            <li class="nav-item"><a class="nav-link" asp-controller="Home" asp-action="Index">Home</a></li>
-            <li class="nav-item"><a class="nav-link" asp-controller="Film" asp-action="Index">Sreach</a></li>
-            <li class="nav-item"><a class="nav-link active" asp-controller="Film" asp-action="Index">Films</a></li>
-            <li class="nav-item"><a class="nav-link" href="#">Series</a></li>
-            <li class="nav-item"><a class="nav-link" href="#">Categories</a></li>
-        </ul>
-        <span class="navbar-text me-3">Noti</span>
-        <div class="dropdown">
-            <a class="nav-link dropdown-toggle p-0" href="#" role="button"
-               id="avatarDropdown" data-bs-toggle="dropdown" aria-expanded="false">
-                <img src="@ViewBag.AvatarUrl"
-                     class="avatar-trigger"
-                     alt="User avatar" />
-            </a>
-            <ul class="dropdown-menu dropdown-menu-end mt-2" aria-labelledby="avatarDropdown">
-                <li><a class="dropdown-item" asp-controller="Home" asp-action="Profile">Profile</a></li>
-                <li><button class="dropdown-item" type="button">Settings</button></li>
-                <li><hr class="dropdown-divider" /></li>
-                <li>
-                    <form asp-controller="Account" asp-action="Logout" method="post" class="m-0">
-                        <button type="submit" class="dropdown-item">Sign out</button>
-                    </form>
-                </li>
-            </ul>
-        </div>
-    </div>
-</nav>
-
-<!-- Thêm padding để nội dung không bị navbar che -->
 <div class="container-fluid main-content" style="padding-top: 70px;">
 
     <link rel="stylesheet" href="~/css/film.css" />

--- a/Netflixx/Views/Film/WatchScreen.cshtml
+++ b/Netflixx/Views/Film/WatchScreen.cshtml
@@ -11,6 +11,7 @@
 <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@200;300;400;500;600;700;800;900&display=swap" rel="stylesheet" />
 <link href="~/lib/bootstrap/dist/css/bootstrap.min.css" rel="stylesheet" />
 <link href="~/css/fontawesome.css" rel="stylesheet" />
+<link rel="stylesheet" href="~/css/homepage.css" />
 
 <style>
     body {
@@ -127,48 +128,7 @@
 </style>
 
 <header>
-    <nav class="navbar navbar-expand-lg navbar-dark bg-dark fixed-top">
-
-        <div class="container-fluid">
-            <a class="navbar-brand" asp-area="" asp-controller="Home" asp-action="Index">
-                <img src="/image/logo/NetflixxLogo.png"
-                     alt="Netflixx Logo"
-                     style="height:40px;" />
-            </a>
-            <ul class="navbar-nav me-auto">
-                <li class="nav-item"><a class="nav-link active" asp-controller="Home" asp-action="Index">Home</a></li>
-                <li class="nav-item"><a class="nav-link" asp-controller="Film" asp-action="Index">Search</a></li>
-                <li class="nav-item"><a class="nav-link" asp-controller="Film" asp-action="Type">Films</a></li>
-                <li class="nav-item"><a class="nav-link" asp-controller="Filmpackage" asp-action="Index">Film Package</a></li>
-                <li class="nav-item"><a class="nav-link" asp-controller="Blog" asp-action="Index">Blog</a></li>
-                <li class="nav-item"><a class="nav-link" asp-area="ShopSouvenir" asp-controller="Home" asp-action="Index">Souvenir</a></li>
-                <li class="nav-item"><a class="nav-link" asp-area="ProductionManager" asp-controller="ProductionManager" asp-action="Index">List Company</a></li>
-                <li class="nav-item"><a class="nav-link" href="#">Series</a></li>
-                <li class="nav-item"><a class="nav-link" href="#">Categories</a></li>
-            </ul>
-            <span class="navbar-text me-3"><i class="fa fa-bell"></i></span>
-            <div class="dropdown">
-                <a class="nav-link dropdown-toggle p-0" role="button"
-                   id="avatarDropdown" data-bs-toggle="dropdown" aria-expanded="false">
-                    <img src="@ViewBag.AvatarUrl"
-                         class="avatar-trigger"
-                         alt="User avatar" />
-                </a>
-                <ul class="dropdown-menu dropdown-menu-end mt-2" aria-labelledby="avatarDropdown">
-                    <li><a class="dropdown-item" asp-controller="Home" asp-action="Profile">Profile</a></li>
-                    <li><a class="dropdown-item" asp-controller="Home" asp-action="History">History</a></li>
-                    <li><a class="dropdown-item" asp-controller="Home" asp-action="MyList">My List</a></li>
-                    <li><button class="dropdown-item" type="button">Settings</button></li>
-                    <li><hr class="dropdown-divider" /></li>
-                    <li>
-                        <form asp-controller="Logout" asp-action="Logout" method="post" class="m-0">
-                            <button type="submit" class="dropdown-item">Sign out</button>
-                        </form>
-                    </li>
-                </ul>
-            </div>
-        </div>
-    </nav>
+    @await Html.PartialAsync("_HomeMenu")
 </header>
 
 <div class="container-fluid py-4" style="margin-top:70px;">

--- a/Netflixx/Views/Shared/_Layout.cshtml
+++ b/Netflixx/Views/Shared/_Layout.cshtml
@@ -8,6 +8,7 @@
     <link rel="stylesheet" href="~/lib/bootstrap/dist/css/bootstrap.min.css" />
     <link rel="stylesheet" href="~/lib/bootstrap/dist/css/bootstrap-theme.min.css" />
     <link rel="stylesheet" href="~/css/site.css" asp-append-version="true" />
+    <link rel="stylesheet" href="~/css/homepage.css" />
     <link rel="stylesheet" href="~/Netflixx.styles.css" asp-append-version="true" />
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/sweetalert2@11/dist/sweetalert2.min.css">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css">


### PR DESCRIPTION
## Summary
- load `homepage.css` in the site layout
- use layout navbar instead of duplicating markup in film list and search detail pages
- include shared header via partial on watch and detail views
- add `homepage.css` for manager pages

## Testing
- `dotnet build Netflixx/Netflixx.csproj -clp:ErrorsOnly` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6874cb5050dc8326851a0d4532205de4