### PR TITLE
Add manager menu with ProductionManager and film links

### DIFF
--- a/Netflixx/Areas/Manager/Views/Index.cshtml
+++ b/Netflixx/Areas/Manager/Views/Index.cshtml
@@ -1,1 +1,14 @@
-﻿
+@{
+    ViewData["Title"] = "Manager Dashboard";
+}
+
+@await Html.PartialAsync("_ManagerMenu")
+
+<div class="main-content" id="mainContent">
+    <div class="container-fluid px-4 py-3">
+        <h2 class="page-title mb-0 text-white">Manager Dashboard</h2>
+        <p class="text-muted mb-0">Welcome to the manager area.</p>
+    </div>
+</div>
+
+@await Html.PartialAsync("_ManagerMenuScripts")

--- a/Netflixx/Areas/Manager/Views/Shared/_ManagerMenu.cshtml
+++ b/Netflixx/Areas/Manager/Views/Shared/_ManagerMenu.cshtml
@@ -1,0 +1,96 @@
+<style>
+    body {
+        background-color: #1f1f1f;
+        color: #fff;
+        transition: margin-left 0.3s;
+        overflow-x: hidden;
+    }
+
+    .navbar {
+        z-index: 1100;
+    }
+
+    .sidebar {
+        position: fixed;
+        top: 70px;
+        left: 0;
+        height: calc(100vh - 70px);
+        width: 230px;
+        background-color: #2c2c2c;
+        overflow-y: auto;
+        transition: transform 0.3s ease;
+        z-index: 1000;
+        display: flex;
+        flex-direction: column;
+        border-right: 1px solid #444;
+    }
+
+        .sidebar.collapsed {
+            transform: translateX(-100%);
+        }
+
+        .sidebar a {
+            display: block;
+            padding: 15px 20px;
+            color: #fff;
+            text-decoration: none;
+            white-space: nowrap;
+        }
+
+            .sidebar a:hover {
+                background-color: #ff4d6d;
+            }
+
+    .main-content {
+        margin-left: 230px;
+        padding: 100px 20px 20px;
+        transition: margin-left 0.3s ease;
+    }
+
+        .main-content.expanded {
+            margin-left: 0;
+        }
+
+    .toggle-btn,
+    .show-sidebar-btn {
+        position: fixed;
+        top: 75px;
+        z-index: 1200;
+        background-color: #ff4d6d;
+        color: #fff;
+        border: none;
+        padding: 5px 10px;
+        border-radius: 5px;
+    }
+
+    .toggle-btn {
+        left: 10px;
+    }
+
+    .show-sidebar-btn {
+        left: 10px;
+        display: none;
+    }
+
+    .sidebar.collapsed ~ .show-sidebar-btn {
+        display: block;
+    }
+</style>
+
+<div class="sidebar" id="sidebar">
+    <div>
+        <h5 class="px-3 py-2 mb-0 text-uppercase fw-semibold text-white text-center">Manager Menu</h5>
+        <a asp-area="ProductionManager" asp-controller="ProductionManager" asp-action="Index"><i class="fas fa-industry"></i> Production Manager</a>
+        <a asp-controller="Film" asp-action="Search"><i class="fas fa-film"></i> Film Manager</a>
+    </div>
+</div>
+
+<div>
+    <button id="toggleSidebar" class="toggle-btn">
+        <i class="fas fa-angle-double-left"></i>
+    </button>
+
+    <button id="showSidebar" class="show-sidebar-btn">
+        <i class="fas fa-angle-double-right"></i>
+    </button>
+</div>

--- a/Netflixx/Areas/Manager/Views/Shared/_ManagerMenuScripts.cshtml
+++ b/Netflixx/Areas/Manager/Views/Shared/_ManagerMenuScripts.cshtml
@@ -1,0 +1,20 @@
+<script>
+    document.addEventListener('DOMContentLoaded', function () {
+        var toggle = document.getElementById('toggleSidebar');
+        var show = document.getElementById('showSidebar');
+        if (toggle) {
+            toggle.addEventListener('click', function () {
+                document.getElementById('sidebar').classList.add('collapsed');
+                document.getElementById('mainContent').classList.add('expanded');
+                if (show) show.style.display = 'block';
+            });
+        }
+        if (show) {
+            show.addEventListener('click', function () {
+                document.getElementById('sidebar').classList.remove('collapsed');
+                document.getElementById('mainContent').classList.remove('expanded');
+                show.style.display = 'none';
+            });
+        }
+    });
+</script>


### PR DESCRIPTION
## Summary
- add a dedicated manager sidebar
- include toggle script for the manager menu
- show the new menu on the manager index page

## Testing
- `npm install`
- `npm run scss` *(fails: Can't find stylesheet to import)*

------
https://chatgpt.com/codex/tasks/task_e_6874d32600448326a5cba3d5f6ac6051