### PR TITLE
Fix Billhistory success alert

### DIFF
--- a/Netflixx/Views/Filmpackage/Billhistory.cshtml
+++ b/Netflixx/Views/Filmpackage/Billhistory.cshtml
@@ -203,6 +203,12 @@
             <h1>Lịch sử giao dịch</h1>
             <p>Theo dõi tất cả các giao dịch và thay đổi điểm trong tài khoản của bạn</p>
         </div>
+        @if (TempData["SuccessMessage"] != null)
+        {
+            <div class="alert alert-success" role="alert">
+                @TempData["SuccessMessage"]
+            </div>
+        }
 
         <div class="stats-overview">
             <div class="stat-card">


### PR DESCRIPTION
## Summary
- display success toast/alert message on Billhistory page when redirected from a successful purchase

## Testing
- `npm test` *(fails: Missing script)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6875265d822083269a5cd336715f51b2