### PR TITLE
Enable paying film packages with coins

### DIFF
--- a/Netflixx/Controllers/FilmpackageController.cs
+++ b/Netflixx/Controllers/FilmpackageController.cs
@@ -1,10 +1,23 @@
 ﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
 using Netflixx.Models;
+using Netflixx.Repositories;
 
 namespace Netflixx.Controllers
 {
     public class FilmpackageController : Controller
     {
+        private readonly UserManager<AppUserModel> _userManager;
+        private readonly DBContext _context;
+
+        public FilmpackageController(UserManager<AppUserModel> userManager, DBContext context)
+        {
+            _userManager = userManager;
+            _context = context;
+        }
+
         public IActionResult Index()
         {
             return View();
@@ -25,6 +38,62 @@ namespace Netflixx.Controllers
             };
 
             return View(model);
+        }
+
+        [Authorize]
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> BuyWithCoins([FromBody] FilmPackageViewModel model)
+        {
+            if (model == null)
+            {
+                return BadRequest();
+            }
+
+            var user = await _userManager.GetUserAsync(User);
+            if (user == null)
+            {
+                return Unauthorized();
+            }
+
+            var account = await _context.UserAccounts.FirstOrDefaultAsync(a => a.UserID == user.Id);
+            if (account == null || account.PointsBalance < model.PackagePrice)
+            {
+                return Json(new { success = false, message = "Không đủ coins." });
+            }
+
+            account.PointsBalance -= model.PackagePrice;
+
+            var package = await _context.Packages.FirstOrDefaultAsync(p => p.Name == model.PackageName);
+            if (package == null)
+            {
+                package = new PackagesModel { Name = model.PackageName };
+                _context.Packages.Add(package);
+                await _context.SaveChangesAsync();
+            }
+
+            var subscription = new PackageSubscriptionsModel
+            {
+                UserID = user.Id,
+                PackageID = package.Id,
+                StartDate = DateTime.UtcNow.Date,
+                EndDate = DateTime.UtcNow.Date.AddMonths(1),
+                Price = model.PackagePrice,
+                Status = "active"
+            };
+            _context.PackageSubscriptions.Add(subscription);
+
+            _context.PointsTransactions.Add(new PointsTransactionsModel
+            {
+                UserID = user.Id,
+                TransactionDate = DateTime.UtcNow,
+                PointsChange = -model.PackagePrice,
+                Reason = $"Buy package {model.PackageName}"
+            });
+
+            await _context.SaveChangesAsync();
+
+            return Json(new { success = true, message = "Thanh toán thành công" });
         }
 
     }

--- a/Netflixx/Views/Filmpackage/Buy.cshtml
+++ b/Netflixx/Views/Filmpackage/Buy.cshtml
@@ -155,6 +155,7 @@
     </style>
 </head>
 <body>
+    @Html.AntiForgeryToken()
     <div class="package-card @packageClass">
         <span class="package-icon">@packageIcon</span>
         <h1>Gói: @Model.PackageName</h1>
@@ -183,31 +184,31 @@
 <script>
     document.getElementById("checkPaymentBtn").addEventListener("click", async function () {
         const price = @Model.PackagePrice;
-        const content = "@username";
+        const packageId = "@Model.PackageId";
+        const packageName = "@Model.PackageName";
         const resultElement = document.getElementById("paymentResult");
 
         try {
-            const response = await fetch(
-
-                "https://script.google.com/macros/s/AKfycbyi5nMWfuHp3BigdOV9h0lq97ci0f1YTWOlULUsRgkW8_AT0e34FVu67ao3l00EXOHx/exec"
-
-            );
+            const response = await fetch('/Filmpackage/BuyWithCoins', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'RequestVerificationToken': document.querySelector('input[name="__RequestVerificationToken"]').value
+                },
+                body: JSON.stringify({ packageId: packageId, packageName: packageName, packagePrice: price })
+            });
             const data = await response.json();
-            const lastPaid = data.data[data.data.length - 1];
-            const lastPrice = parseInt(lastPaid["Giá trị"]);
-            const lastContent = lastPaid["Mô tả"];
-
-            if (lastPrice == price && lastContent.includes(content)) {
-                resultElement.style.color = "lime";
-                resultElement.textContent = "✅ Thanh toán thành công!";
+            if (data.success) {
+                resultElement.style.color = 'lime';
+                resultElement.textContent = '✅ ' + data.message;
             } else {
-                resultElement.style.color = "orange";
-                resultElement.textContent = "⚠️ Chưa nhận được thanh toán. Vui lòng thử lại sau vài phút.";
+                resultElement.style.color = 'orange';
+                resultElement.textContent = '⚠️ ' + data.message;
             }
         } catch (e) {
-            console.error("Lỗi", e);
-            resultElement.style.color = "red";
-            resultElement.textContent = "❌ Đã xảy ra lỗi khi kiểm tra thanh toán.";
+            console.error('Lỗi', e);
+            resultElement.style.color = 'red';
+            resultElement.textContent = '❌ Đã xảy ra lỗi khi thanh toán.';
         }
     });
 </script>


### PR DESCRIPTION
## Summary
- add buy-with-coins endpoint in `FilmpackageController`
- support buying packages using coin balance
- update Buy page script to call new endpoint and add CSRF token

## Testing
- `dotnet build Netflixx.sln`

------
https://chatgpt.com/codex/tasks/task_e_6875321004e883269e9f0df1f1d0074b