### PR TITLE
Add film package list support

### DIFF
--- a/Netflixx/Areas/Manager/Views/Packages/Create.cshtml
+++ b/Netflixx/Areas/Manager/Views/Packages/Create.cshtml
@@ -16,6 +16,11 @@
         <span asp-validation-for="Description" class="text-danger"></span>
     </div>
     <div class="mb-3">
+        <label asp-for="Price" class="form-label"></label>
+        <input asp-for="Price" class="form-control" />
+        <span asp-validation-for="Price" class="text-danger"></span>
+    </div>
+    <div class="mb-3">
         <label class="form-label">Select Films</label>
         <div>
 @foreach (var film in films)

--- a/Netflixx/Areas/Manager/Views/Packages/Index.cshtml
+++ b/Netflixx/Areas/Manager/Views/Packages/Index.cshtml
@@ -11,6 +11,7 @@
         <tr>
             <th>Name</th>
             <th>Description</th>
+            <th>Price</th>
             <th>Films</th>
         </tr>
     </thead>
@@ -20,6 +21,7 @@
         <tr>
             <td>@pkg.Name</td>
             <td>@pkg.Description</td>
+            <td>@pkg.Price.ToString("N0")</td>
             <td>
                 @string.Join(", ", pkg.PackageFilms.Select(pf => pf.Film.Title))
             </td>

--- a/Netflixx/Controllers/FilmpackageController.cs
+++ b/Netflixx/Controllers/FilmpackageController.cs
@@ -1,13 +1,21 @@
 ﻿using Microsoft.AspNetCore.Mvc;
 using Netflixx.Models;
+using Netflixx.Repositories;
 
 namespace Netflixx.Controllers
 {
     public class FilmpackageController : Controller
     {
+        private readonly DBContext _context;
+        public FilmpackageController(DBContext context)
+        {
+            _context = context;
+        }
+
         public IActionResult Index()
         {
-            return View();
+            var packages = _context.Packages.ToList();
+            return View(packages);
         }
 
         public IActionResult Billhistory()

--- a/Netflixx/Migrations/20250715044909_AddPriceToPackages.Designer.cs
+++ b/Netflixx/Migrations/20250715044909_AddPriceToPackages.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Netflixx.Repositories;
 
@@ -11,9 +12,11 @@ using Netflixx.Repositories;
 namespace Netflixx.Migrations
 {
     [DbContext(typeof(DBContext))]
-    partial class DBContextModelSnapshot : ModelSnapshot
+    [Migration("20250715044909_AddPriceToPackages")]
+    partial class AddPriceToPackages
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Netflixx/Migrations/20250715044909_AddPriceToPackages.cs
+++ b/Netflixx/Migrations/20250715044909_AddPriceToPackages.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Netflixx.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddPriceToPackages : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<decimal>(
+                name: "Price",
+                table: "Packages",
+                type: "decimal(18,2)",
+                nullable: false,
+                defaultValue: 0m);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Price",
+                table: "Packages");
+        }
+    }
+}

--- a/Netflixx/Models/PackagesModel.cs
+++ b/Netflixx/Models/PackagesModel.cs
@@ -1,4 +1,5 @@
 ﻿using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
 
 namespace Netflixx.Models
 {
@@ -10,6 +11,11 @@ namespace Netflixx.Models
         [Required(ErrorMessage = "Tên không được để trống.")]
         public string Name { get; set; }
         public string? Description { get; set; }
+
+        [Required]
+        [Column(TypeName = "decimal(18,2)")]
+        [Range(0, double.MaxValue)]
+        public decimal Price { get; set; }
 
         // Navigation properties
         public ICollection<PackageChannelsModel> PackageChannels { get; set; }

--- a/Netflixx/Views/Filmpackage/Index.cshtml
+++ b/Netflixx/Views/Filmpackage/Index.cshtml
@@ -1,4 +1,6 @@
-﻿﻿
+@model IEnumerable<Netflixx.Models.PackagesModel>
+@using Newtonsoft.Json
+
 <!DOCTYPE html>
 <html lang="vi">
 <head>
@@ -18,7 +20,7 @@
         </div>
 
         <div class="package-container">
-            
+
         </div>
 
         <div class="comparison">
@@ -90,5 +92,8 @@
 
     </main>
 </body>
+<script>
+    var filmPackageData = @Html.Raw(JsonConvert.SerializeObject(Model));
+</script>
 <script src="~/js/Filmpackage.js"></script>
 </html>

--- a/Netflixx/wwwroot/js/Filmpackage.js
+++ b/Netflixx/wwwroot/js/Filmpackage.js
@@ -1,4 +1,14 @@
-﻿let filmpackage = [
+let filmpackage = window.filmPackageData && window.filmPackageData.length ? window.filmPackageData.map(p => ({
+    packageId: `package${p.id.toString().padStart(2,'0')}`,
+    packageName: p.name,
+    packagePrice: parseFloat(p.price),
+    features: [
+        "Tất cả tính năng cơ bản",
+        "Xem trên nhiều thiết bị",
+        "Chất lượng video cao"
+    ],
+    btnClass: p.name === "Cơ Bản" ? "basic-btn" : p.name === "Tiêu Chuẩn" ? "standard-btn" : "premium-btn"
+})) : [
     {
         packageId: "package01",
         packageName: "Cơ Bản",


### PR DESCRIPTION
## Summary
- add `Price` field to `PackagesModel` and database migration
- show package `Price` in manager pages
- load packages in `FilmpackageController` and display them in index view
- let `Filmpackage.js` render packages provided by server

## Testing
- `dotnet build ../Netflixx.sln`

------
https://chatgpt.com/codex/tasks/task_e_6875dc3b356483269548c1866b42307c