### PR TITLE
Improve recharge UI

### DIFF
--- a/Netflixx/Views/Payment/Recharge.cshtml
+++ b/Netflixx/Views/Payment/Recharge.cshtml
@@ -1,11 +1,20 @@
 @{
     ViewData["Title"] = "Recharge";
 }
-<h2>Recharge Coins</h2>
-<form asp-action="Recharge" method="post">
-    <div class="mb-3">
-        <label for="amount" class="form-label">Amount (VND)</label>
-        <input type="number" class="form-control" id="amount" name="amount" required min="1" />
+
+<div class="recharge-wrapper">
+    <div class="recharge-card">
+        <h2 class="text-center mb-4">Nạp tiền</h2>
+        <form asp-action="Recharge" method="post">
+            <div class="mb-3">
+                <label for="amount" class="form-label">Số tiền (VND)</label>
+                <input type="number" class="form-control bg-dark text-white border-secondary" id="amount" name="amount" required min="1" />
+            </div>
+            <button type="submit" class="btn btn-danger w-100">Thanh toán qua VNPAY</button>
+        </form>
     </div>
-    <button type="submit" class="btn btn-primary">Pay with VNPAY</button>
-</form>
+</div>
+
+@section Styles {
+    <link rel="stylesheet" href="~/css/recharge.css" />
+}

--- a/Netflixx/Views/Payment/RechargeResult.cshtml
+++ b/Netflixx/Views/Payment/RechargeResult.cshtml
@@ -2,12 +2,23 @@
 @{
     ViewData["Title"] = "Recharge Result";
 }
-@if (Model)
-{
-    <div class="alert alert-success">Recharge successful!</div>
+
+<div class="recharge-wrapper">
+    <div class="recharge-result-card text-center">
+        @if (Model)
+        {
+            <div class="result-icon text-success mb-3"><i class="bi bi-check-circle-fill"></i></div>
+            <h3>Nạp tiền thành công!</h3>
+        }
+        else
+        {
+            <div class="result-icon text-danger mb-3"><i class="bi bi-x-circle-fill"></i></div>
+            <h3>Nạp tiền thất bại!</h3>
+        }
+        <a asp-action="Recharge" class="btn btn-outline-light mt-4">Quay lại</a>
+    </div>
+</div>
+
+@section Styles {
+    <link rel="stylesheet" href="~/css/recharge.css" />
 }
-else
-{
-    <div class="alert alert-danger">Recharge failed!</div>
-}
-<a asp-action="Recharge" class="btn btn-secondary">Back</a>

--- a/Netflixx/wwwroot/css/recharge.css
+++ b/Netflixx/wwwroot/css/recharge.css
@@ -1,0 +1,33 @@
+.recharge-wrapper {
+    min-height: calc(100vh - 80px);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 40px 15px;
+}
+
+.recharge-card,
+.recharge-result-card {
+    background-color: rgba(0, 0, 0, 0.8);
+    border: 1px solid #333;
+    border-radius: 8px;
+    padding: 2rem;
+    color: #fff;
+    box-shadow: 0 10px 25px rgba(0, 0, 0, 0.6);
+    width: 100%;
+    max-width: 420px;
+}
+
+.recharge-card .btn-danger {
+    background-color: #e50914;
+    border-color: #e50914;
+}
+
+.recharge-card .btn-danger:hover {
+    background-color: #bf0810;
+    border-color: #bf0810;
+}
+
+.result-icon {
+    font-size: 4rem;
+}


### PR DESCRIPTION
## Summary
- restyle the recharge form using a centered card layout
- add success and failure display with icons
- create `recharge.css` for recharge page styles

## Testing
- `npm install`
- `npm run scss` *(fails: Can't find stylesheet to import)*

------
https://chatgpt.com/codex/tasks/task_e_68761f75fe208326b5aafbcfe0a963b3