### PR TITLE
Remove decimals from film price displays

### DIFF
--- a/Netflixx/Views/Blog/Details.cshtml
+++ b/Netflixx/Views/Blog/Details.cshtml
@@ -114,7 +114,7 @@
                                             {
                                                 <span class="badge bg-success ms-2">
                                                     <i class="bi bi-tag me-1"></i>
-                                                    $@Model.Film.Price.Value.ToString("0.00")
+                                                    $@Model.Film.Price.Value.ToString("0")
                                                 </span>
                                             }
                                         </div>

--- a/Netflixx/Views/Film/Detail.cshtml
+++ b/Netflixx/Views/Film/Detail.cshtml
@@ -210,7 +210,7 @@
                             @Html.AntiForgeryToken()
                             <input type="hidden" name="id" value="@Model.Film.Id" />
                             <button type="submit" class="btn btn-danger w-100" style="height:314px;">
-                                Mua - @Model.Film.Price coins
+                                Mua - @Model.Film.Price.ToString("N0") coins
                             </button>
                         </form>
                     }
@@ -237,7 +237,7 @@
                             </span>
                             <span>
                                 <i class="fa fa-dollar-sign" style="color: red"></i>
-                                @Model.Film.Price?.ToString()
+                                @Model.Film.Price?.ToString("N0")
                             </span>
                         </div>
                     </div>

--- a/Netflixx/Views/Film/DetailSreach.cshtml
+++ b/Netflixx/Views/Film/DetailSreach.cshtml
@@ -21,7 +21,7 @@
             <h1 class="text-light">@Model.Title</h1>
             <p><strong class="text-info">Thể loại:</strong> <span class="text-light">@Model.Genre</span></p>
             <p><strong class="text-info">Ngày:</strong> <span class="text-light">@Model.ReleaseDate?.ToString("dd/MM/yyyy")</span></p>
-            <p><strong class="text-info">Giá:</strong> <span class="text-light">@Model.Price coins</span></p>
+            <p><strong class="text-info">Giá:</strong> <span class="text-light">@Model.Price.ToString("N0") coins</span></p>
             <p><strong class="text-info">Đánh giá:</strong> <span class="text-light">@Model.Rating/10</span></p>
 
             <h3 class="mt-4 text-light">Description</h3>

--- a/Netflixx/Views/Film/Index.cshtml
+++ b/Netflixx/Views/Film/Index.cshtml
@@ -75,7 +75,7 @@
                     <p class="card-text">
                         <strong>Thể loại:</strong> @film.Genre<br>
                         <strong>Ngày:</strong> @film.ReleaseDate?.ToString("dd/MM/yyyy")<br>
-                        <strong>Giá:</strong> @film.Price coins<br>
+                        <strong>Giá:</strong> @film.Price.ToString("N0") coins<br>
                         <strong>Đánh giá:</strong> @film.Rating/10
                     </p>
                 </div>

--- a/Netflixx/Views/Film/ManagerFilm/DeletedFilms.cshtml
+++ b/Netflixx/Views/Film/ManagerFilm/DeletedFilms.cshtml
@@ -502,7 +502,7 @@
                                                                         '@item.ReleaseDate?.ToString("dd/MM/yyyy")',
                                                                         '@item.Genre',
                                                                         '@Html.Raw(item.Description?.Replace("'", "\\'") ?? "")',
-                                                                        '@(item.Price?.ToString() ?? "0")',
+                                                                        '@(item.Price?.ToString("N0") ?? "0")',
                                                                         '@item.FilmURL',
                                                                         '@item.PosterPath',
                                                                         '@item.Duration',
@@ -710,7 +710,7 @@
             // Format giá tiền với đơn vị coin
             const priceValue = parseFloat(price);
             $('#detailPrice').text(!isNaN(priceValue) ?
-                priceValue.toLocaleString('vi-VN') + ' coins' : 'N/A');
+                priceValue.toLocaleString('vi-VN', {maximumFractionDigits:0}) + ' coins' : 'N/A');
 
             $('#detailFilmURL').attr('href', filmURL || '#');
             $('#detailActors').text(actors || 'N/A');

--- a/Netflixx/Views/Film/ManagerFilm/SearchFilms.cshtml
+++ b/Netflixx/Views/Film/ManagerFilm/SearchFilms.cshtml
@@ -583,7 +583,7 @@
                     '@Html.Raw(item.Actors?.Replace("'", "\\'") ?? "")',
                     '@Html.Raw(item.Description?.Replace("'", "\\'") ?? "")',
                     '@item.TrailerURL',
-                    '@(item.Price?.ToString() ?? "0")',
+                    '@(item.Price?.ToString("N0") ?? "0")',
                     '@item.FilmURL',
                     '@item.ProductionManagerId')">
                                                     <i class="fas fa-edit"></i>
@@ -595,7 +595,7 @@
                                                                                             '@item.ReleaseDate?.ToString("dd/MM/yyyy")',
                                                                                             '@item.Genre',
                                                                                             '@Html.Raw(item.Description?.Replace("'", "\\'") ?? "")',
-                                                                                            '@(item.Price?.ToString() ?? "0")',
+                    '@(item.Price?.ToString("N0") ?? "0")',
                                                                                             '@item.FilmURL',
                                                                                             '@item.PosterPath',
                                                                                             '@item.Duration',
@@ -908,7 +908,7 @@
                 // Format giá tiền với đơn vị coin
                 const priceValue = parseFloat(price);
                 $('#detailPrice').text(!isNaN(priceValue) ?
-                    priceValue.toLocaleString('vi-VN') + ' coins' : 'N/A');
+                    priceValue.toLocaleString('vi-VN', {maximumFractionDigits:0}) + ' coins' : 'N/A');
 
                 $('#detailFilmURL').attr('href', filmURL || '#');
                 $('#detailActors').text(actors || 'N/A');

--- a/Netflixx/Views/Film/Type.cshtml
+++ b/Netflixx/Views/Film/Type.cshtml
@@ -100,7 +100,7 @@
                             <p class="card-text">
                                 <strong>Thể loại:</strong> @film.Genre<br>
                                 <strong>Ngày:</strong> @film.ReleaseDate?.ToString("dd/MM/yyyy")<br>
-                                <strong>Giá:</strong> @film.Price coins<br>
+                                <strong>Giá:</strong> @film.Price.ToString("N0") coins<br>
                                 <strong>Đánh giá:</strong> @film.Rating/10
                             </p>
                         </div>
@@ -158,7 +158,7 @@
                             <p class="card-text">
                                 <strong>Thể loại:</strong> @film.Genre<br>
                                 <strong>Ngày:</strong> @film.ReleaseDate?.ToString("dd/MM/yyyy")<br>
-                                <strong>Giá:</strong> @film.Price coins<br>
+                                <strong>Giá:</strong> @film.Price.ToString("N0") coins<br>
                                 <strong>Đánh giá:</strong> @film.Rating/10
                             </p>
                         </div>
@@ -219,7 +219,7 @@
                             <p class="card-text">
                                 <strong>Thể loại:</strong> @film.Genre<br>
                                 <strong>Ngày:</strong> @film.ReleaseDate?.ToString("dd/MM/yyyy")<br>
-                                <strong>Giá:</strong> @film.Price coins<br>
+                                <strong>Giá:</strong> @film.Price.ToString("N0") coins<br>
                                 <strong>Đánh giá:</strong> @film.Rating/10
                             </p>
                         </div>

--- a/Netflixx/Views/Films/Details.cshtml
+++ b/Netflixx/Views/Films/Details.cshtml
@@ -24,7 +24,7 @@
                 }
                 @if (Model.Price.HasValue)
                 {
-                    <span class="price-badge fs-5 text-danger ms-2">@Model.Price.Value.ToString("C")</span>
+                    <span class="price-badge fs-5 text-danger ms-2">@Model.Price.Value.ToString("C0")</span>
                 }
             </div>
 

--- a/Netflixx/Views/Films/Index.cshtml
+++ b/Netflixx/Views/Films/Index.cshtml
@@ -29,7 +29,7 @@
                         <p class="card-text text-truncate">@item.Description</p>
                         @if (item.Price.HasValue)
                         {
-                            <div class="price-badge fs-5 text-danger">@item.Price.Value.ToString("C")</div>
+                            <div class="price-badge fs-5 text-danger">@item.Price.Value.ToString("C0")</div>
                         }
                         <a asp-action="Details" asp-route-id="@item.Id" class="btn btn-sm btn-outline-danger mt-2">View Details</a>
                     </div>

--- a/Netflixx/Views/Home/Index.cshtml
+++ b/Netflixx/Views/Home/Index.cshtml
@@ -200,7 +200,7 @@
                             <h4>@film.Title<br><span>@film.Genre</span></h4>
                             <ul>
                                 <li><i class="fa fa-star"></i> @film.Rating</li>
-                                <li><i class="fa fa-dollar-sign"></i> @(film.Price.HasValue ? $"{film.Price:F2}" : "Free")</li>
+                                <li><i class="fa fa-dollar-sign"></i> @(film.Price.HasValue ? $"{film.Price:F0}" : "Free")</li>
                             </ul>
                         </div>
                     </div>
@@ -224,7 +224,7 @@
                             <h4>@film.Title<br><span>@film.Genre</span></h4>
                             <ul>
                                 <li><i class="fa fa-star-o"></i> @film.Rating</li>
-                                <li><i class="fa fa-dollar-sign"></i> @(film.Price.HasValue ? $"{film.Price:F2}" : "Free")</li>
+                                <li><i class="fa fa-dollar-sign"></i> @(film.Price.HasValue ? $"{film.Price:F0}" : "Free")</li>
                             </ul>
                         </div>
                     </div>


### PR DESCRIPTION
## Summary
- format film price without decimals on film cards and details
- round film prices in blog and management views
- ensure modal JS uses whole numbers for coins

## Testing
- `npm run scss` *(fails: `sass` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687638b0852c8326ad6a71d25f1f50a3