### PR TITLE
Add purchase confirmation prompt

### DIFF
--- a/Netflixx/Views/Film/Detail.cshtml
+++ b/Netflixx/Views/Film/Detail.cshtml
@@ -532,7 +532,7 @@
 
             Swal.fire({
                 title: 'Xác nhận mua?',
-                text: 'Bạn có chắc chắn muốn mua phim này?',
+                text: 'Bạn có muốn mua phim này không?',
                 icon: 'question',
                 showCancelButton: true,
                 confirmButtonColor: '#e50914',

--- a/Netflixx/Views/Film/Index.cshtml
+++ b/Netflixx/Views/Film/Index.cshtml
@@ -94,7 +94,7 @@
                     }
                     else if (currentUser != null)
                     {
-                        <form asp-action="Purchase" method="post" class="d-inline">
+                        <form asp-action="Purchase" method="post" class="d-inline purchase-form">
                             @Html.AntiForgeryToken()
                             <input type="hidden" name="id" value="@film.Id" />
                             <button type="submit" class="btn btn-danger">Mua</button>
@@ -113,8 +113,31 @@
 
 @if (Model.Count == 0)
 {
-    <div class="alert alert-info" style="text-align: center;"> 
+    <div class="alert alert-info" style="text-align: center;">
             Không tìm thấy phim nào phù hợp với tiêu chí của bạn. Vui lòng thử bộ lọc khác.
     </div>
 }
 </div>
+<script>
+    document.addEventListener('DOMContentLoaded', () => {
+        document.querySelectorAll('form.purchase-form').forEach(form => {
+            form.addEventListener('submit', function (e) {
+                e.preventDefault();
+                Swal.fire({
+                    title: 'Xác nhận mua?',
+                    text: 'Bạn có muốn mua phim này không?',
+                    icon: 'question',
+                    showCancelButton: true,
+                    confirmButtonColor: '#e50914',
+                    cancelButtonColor: '#6c757d',
+                    confirmButtonText: 'Mua',
+                    cancelButtonText: 'Hủy'
+                }).then((result) => {
+                    if (result.isConfirmed) {
+                        form.submit();
+                    }
+                });
+            });
+        });
+    });
+</script>

--- a/Netflixx/Views/Film/Type.cshtml
+++ b/Netflixx/Views/Film/Type.cshtml
@@ -119,7 +119,7 @@
                             }
                             else if (currentUser != null)
                             {
-                                <form asp-action="Purchase" method="post" class="d-inline">
+                                <form asp-action="Purchase" method="post" class="d-inline purchase-form">
                                     @Html.AntiForgeryToken()
                                     <input type="hidden" name="id" value="@film.Id" />
                                     <button type="submit" class="btn btn-danger">Mua</button>
@@ -177,7 +177,7 @@
                             }
                             else if (currentUser != null)
                             {
-                                <form asp-action="Purchase" method="post" class="d-inline">
+                                <form asp-action="Purchase" method="post" class="d-inline purchase-form">
                                     @Html.AntiForgeryToken()
                                     <input type="hidden" name="id" value="@film.Id" />
                                     <button type="submit" class="btn btn-danger">Mua</button>
@@ -238,7 +238,7 @@
                             }
                             else if (currentUser != null)
                             {
-                                <form asp-action="Purchase" method="post" class="d-inline">
+                                <form asp-action="Purchase" method="post" class="d-inline purchase-form">
                                     @Html.AntiForgeryToken()
                                     <input type="hidden" name="id" value="@film.Id" />
                                     <button type="submit" class="btn btn-danger">Mua</button>
@@ -263,6 +263,30 @@
         </div>
     }
 </div>
+
+<script>
+    document.addEventListener('DOMContentLoaded', () => {
+        document.querySelectorAll('form.purchase-form').forEach(form => {
+            form.addEventListener('submit', function (e) {
+                e.preventDefault();
+                Swal.fire({
+                    title: 'Xác nhận mua?',
+                    text: 'Bạn có muốn mua phim này không?',
+                    icon: 'question',
+                    showCancelButton: true,
+                    confirmButtonColor: '#e50914',
+                    cancelButtonColor: '#6c757d',
+                    confirmButtonText: 'Mua',
+                    cancelButtonText: 'Hủy'
+                }).then((result) => {
+                    if (result.isConfirmed) {
+                        form.submit();
+                    }
+                });
+            });
+        });
+    });
+</script>
 
 <style>
     .filter-bar {


### PR DESCRIPTION
## Summary
- add confirmation dialog before submitting purchase form on film index and type pages
- adjust purchase text on detail page

## Testing
- `dotnet build Netflixx/Netflixx.csproj` *(fails: CS1501)*

------
https://chatgpt.com/codex/tasks/task_e_68763c40f9a48326b22372b069e67abb