### PR TITLE
Fix format string error for nullable Price

### DIFF
--- a/Netflixx/Views/Film/Detail.cshtml
+++ b/Netflixx/Views/Film/Detail.cshtml
@@ -210,7 +210,7 @@
                             @Html.AntiForgeryToken()
                             <input type="hidden" name="id" value="@Model.Film.Id" />
                             <button type="submit" class="btn btn-danger w-100" style="height:314px;">
-                                Mua - @Model.Film.Price.ToString("N0") coins
+                                Mua - @Model.Film.Price?.ToString("N0") coins
                             </button>
                         </form>
                     }

--- a/Netflixx/Views/Film/DetailSreach.cshtml
+++ b/Netflixx/Views/Film/DetailSreach.cshtml
@@ -21,7 +21,7 @@
             <h1 class="text-light">@Model.Title</h1>
             <p><strong class="text-info">Thể loại:</strong> <span class="text-light">@Model.Genre</span></p>
             <p><strong class="text-info">Ngày:</strong> <span class="text-light">@Model.ReleaseDate?.ToString("dd/MM/yyyy")</span></p>
-            <p><strong class="text-info">Giá:</strong> <span class="text-light">@Model.Price.ToString("N0") coins</span></p>
+            <p><strong class="text-info">Giá:</strong> <span class="text-light">@Model.Price?.ToString("N0") coins</span></p>
             <p><strong class="text-info">Đánh giá:</strong> <span class="text-light">@Model.Rating/10</span></p>
 
             <h3 class="mt-4 text-light">Description</h3>

--- a/Netflixx/Views/Film/Index.cshtml
+++ b/Netflixx/Views/Film/Index.cshtml
@@ -75,7 +75,7 @@
                     <p class="card-text">
                         <strong>Thể loại:</strong> @film.Genre<br>
                         <strong>Ngày:</strong> @film.ReleaseDate?.ToString("dd/MM/yyyy")<br>
-                        <strong>Giá:</strong> @film.Price.ToString("N0") coins<br>
+                        <strong>Giá:</strong> @film.Price?.ToString("N0") coins<br>
                         <strong>Đánh giá:</strong> @film.Rating/10
                     </p>
                 </div>

--- a/Netflixx/Views/Film/Type.cshtml
+++ b/Netflixx/Views/Film/Type.cshtml
@@ -100,7 +100,7 @@
                             <p class="card-text">
                                 <strong>Thể loại:</strong> @film.Genre<br>
                                 <strong>Ngày:</strong> @film.ReleaseDate?.ToString("dd/MM/yyyy")<br>
-                                <strong>Giá:</strong> @film.Price.ToString("N0") coins<br>
+                                <strong>Giá:</strong> @film.Price?.ToString("N0") coins<br>
                                 <strong>Đánh giá:</strong> @film.Rating/10
                             </p>
                         </div>
@@ -158,7 +158,7 @@
                             <p class="card-text">
                                 <strong>Thể loại:</strong> @film.Genre<br>
                                 <strong>Ngày:</strong> @film.ReleaseDate?.ToString("dd/MM/yyyy")<br>
-                                <strong>Giá:</strong> @film.Price.ToString("N0") coins<br>
+                                <strong>Giá:</strong> @film.Price?.ToString("N0") coins<br>
                                 <strong>Đánh giá:</strong> @film.Rating/10
                             </p>
                         </div>
@@ -219,7 +219,7 @@
                             <p class="card-text">
                                 <strong>Thể loại:</strong> @film.Genre<br>
                                 <strong>Ngày:</strong> @film.ReleaseDate?.ToString("dd/MM/yyyy")<br>
-                                <strong>Giá:</strong> @film.Price.ToString("N0") coins<br>
+                                <strong>Giá:</strong> @film.Price?.ToString("N0") coins<br>
                                 <strong>Đánh giá:</strong> @film.Rating/10
                             </p>
                         </div>


### PR DESCRIPTION
## Summary
- fix compile errors by using null-safe `ToString` when formatting film price

## Testing
- `dotnet build Netflixx/Netflixx.csproj -c Release`

------
https://chatgpt.com/codex/tasks/task_e_68763e1149e0832685d787ef2609ac61