### PR TITLE
Fix purchase error handling

### DIFF
--- a/Netflixx/Views/Film/Index.cshtml
+++ b/Netflixx/Views/Film/Index.cshtml
@@ -134,7 +134,43 @@
                     cancelButtonText: 'Hủy'
                 }).then((result) => {
                     if (result.isConfirmed) {
-                        form.submit();
+                        const data = new FormData(form);
+                        fetch(form.action, {
+                            method: 'POST',
+                            headers: { 'X-Requested-With': 'XMLHttpRequest' },
+                            body: data
+                        })
+                            .then(r => r.json())
+                            .then(json => {
+                                if (json.success) {
+                                    const link = document.createElement('a');
+                                    link.href = json.redirectUrl;
+                                    link.className = 'btn btn-primary';
+                                    link.textContent = 'Xem ngay';
+                                    form.replaceWith(link);
+                                    Swal.fire({
+                                        icon: 'success',
+                                        title: 'Thành công',
+                                        text: 'Mua phim thành công!',
+                                        confirmButtonColor: '#e50914'
+                                    });
+                                } else {
+                                    Swal.fire({
+                                        icon: 'error',
+                                        title: 'Lỗi',
+                                        text: json.message || 'Not enough coins',
+                                        confirmButtonColor: '#e50914'
+                                    });
+                                }
+                            })
+                            .catch(() => {
+                                Swal.fire({
+                                    icon: 'error',
+                                    title: 'Lỗi',
+                                    text: 'Đã xảy ra lỗi!',
+                                    confirmButtonColor: '#e50914'
+                                });
+                            });
                     }
                 });
             });

--- a/Netflixx/Views/Film/Type.cshtml
+++ b/Netflixx/Views/Film/Type.cshtml
@@ -280,7 +280,43 @@
                     cancelButtonText: 'Hủy'
                 }).then((result) => {
                     if (result.isConfirmed) {
-                        form.submit();
+                        const data = new FormData(form);
+                        fetch(form.action, {
+                            method: 'POST',
+                            headers: { 'X-Requested-With': 'XMLHttpRequest' },
+                            body: data
+                        })
+                            .then(r => r.json())
+                            .then(json => {
+                                if (json.success) {
+                                    const link = document.createElement('a');
+                                    link.href = json.redirectUrl;
+                                    link.className = 'btn btn-primary';
+                                    link.textContent = 'Xem ngay';
+                                    form.replaceWith(link);
+                                    Swal.fire({
+                                        icon: 'success',
+                                        title: 'Thành công',
+                                        text: 'Mua phim thành công!',
+                                        confirmButtonColor: '#e50914'
+                                    });
+                                } else {
+                                    Swal.fire({
+                                        icon: 'error',
+                                        title: 'Lỗi',
+                                        text: json.message || 'Not enough coins',
+                                        confirmButtonColor: '#e50914'
+                                    });
+                                }
+                            })
+                            .catch(() => {
+                                Swal.fire({
+                                    icon: 'error',
+                                    title: 'Lỗi',
+                                    text: 'Đã xảy ra lỗi!',
+                                    confirmButtonColor: '#e50914'
+                                });
+                            });
                     }
                 });
             });


### PR DESCRIPTION
## Summary
- ensure purchase buttons on index and type pages check coin balance via AJAX
- show SweetAlert errors when balance is insufficient instead of redirecting

## Testing
- `npm run scss`

------
https://chatgpt.com/codex/tasks/task_e_687642419a448326b2429ba87f701a90