### PR TITLE
Update coin warning message

### DIFF
--- a/Netflixx/Controllers/FilmController.cs
+++ b/Netflixx/Controllers/FilmController.cs
@@ -322,7 +322,7 @@ namespace Netflixx.Controllers
             var priceCoins = film.Price.HasValue ? (int)Math.Ceiling(film.Price.Value) : 0;
             if (account == null || film.Price == null || account.PointsBalance < priceCoins)
             {
-                var msg = "Not enough coins";
+                var msg = "vui lòng nạp thêm coins";
                 if (Request.Headers["X-Requested-With"] == "XMLHttpRequest")
                 {
                     return Json(new { success = false, message = msg });

--- a/Netflixx/Views/Film/Detail.cshtml
+++ b/Netflixx/Views/Film/Detail.cshtml
@@ -573,8 +573,8 @@
                             } else {
                                 Swal.fire({
                                     icon: 'error',
-                                    title: 'Lỗi',
-                                    text: json.message || 'Not enough coins',
+                                    title: 'Không đủ coins',
+                                    text: json.message || 'vui lòng nạp thêm coins',
                                     confirmButtonColor: '#e50914'
                                 });
                             }

--- a/Netflixx/Views/Film/Index.cshtml
+++ b/Netflixx/Views/Film/Index.cshtml
@@ -157,8 +157,8 @@
                                 } else {
                                     Swal.fire({
                                         icon: 'error',
-                                        title: 'Lỗi',
-                                        text: json.message || 'Not enough coins',
+                                        title: 'Không đủ coins',
+                                        text: json.message || 'vui lòng nạp thêm coins',
                                         confirmButtonColor: '#e50914'
                                     });
                                 }

--- a/Netflixx/Views/Film/Type.cshtml
+++ b/Netflixx/Views/Film/Type.cshtml
@@ -303,8 +303,8 @@
                                 } else {
                                     Swal.fire({
                                         icon: 'error',
-                                        title: 'Lỗi',
-                                        text: json.message || 'Not enough coins',
+                                        title: 'Không đủ coins',
+                                        text: json.message || 'vui lòng nạp thêm coins',
                                         confirmButtonColor: '#e50914'
                                     });
                                 }


### PR DESCRIPTION
## Summary
- update server-side message when user doesn't have enough coins
- update SweetAlert dialogs to show localized message when balance is insufficient

## Testing
- `dotnet test Netflixx.sln` *(fails: no tests found but restored packages)*

------
https://chatgpt.com/codex/tasks/task_e_6876471011c483269fac7a4dfbe9a87b