### PR TITLE
Create separate user account on sign up

### DIFF
--- a/Netflixx/Controllers/LoginController.cs
+++ b/Netflixx/Controllers/LoginController.cs
@@ -186,6 +186,16 @@ namespace Netflixx.Controllers
 
             if (result.Succeeded)
             {
+                // create separate account record for this user
+                var account = new UserAccountsModel
+                {
+                    UserID = user.Id,
+                    Balance = 0,
+                    PointsBalance = 0
+                };
+                _dbContext.UserAccounts.Add(account);
+                await _dbContext.SaveChangesAsync();
+
                 await _signInManager.SignInAsync(user, isPersistent: false);
                 return RedirectToAction("SignUpSuccess"); // Chuyển hướng đến trang thành công
             }


### PR DESCRIPTION
## Summary
- create a `UserAccountsModel` entry whenever a user signs up so coins and purchases stay per-account

## Testing
- `dotnet build Netflixx.sln` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687649991e348326a7e962a39dfbd60c