### PR TITLE
Add film purchase history to bill page

### DIFF
--- a/Netflixx/Controllers/FilmpackageController.cs
+++ b/Netflixx/Controllers/FilmpackageController.cs
@@ -43,10 +43,17 @@ namespace Netflixx.Controllers
                 .OrderByDescending(p => p.StartDate)
                 .FirstOrDefaultAsync();
 
+            var filmPurchases = await _context.FilmPurchases
+                .Include(fp => fp.Film)
+                .Where(fp => fp.UserID == user.Id)
+                .OrderByDescending(fp => fp.PurchaseDate)
+                .ToListAsync();
+
             var vm = new BillHistoryViewModel
             {
                 CurrentPackage = currentPackage,
-                Transactions = transactions
+                Transactions = transactions,
+                FilmPurchases = filmPurchases
             };
 
             return View(vm);

--- a/Netflixx/Models/ViewModel/BillHistoryViewModel.cs
+++ b/Netflixx/Models/ViewModel/BillHistoryViewModel.cs
@@ -7,5 +7,6 @@ namespace Netflixx.Models.ViewModel
     {
         public PackageSubscriptionsModel? CurrentPackage { get; set; }
         public List<PaymentTransactionsModel> Transactions { get; set; } = new();
+        public List<FilmPurchasesModel> FilmPurchases { get; set; } = new();
     }
 }

--- a/Netflixx/Views/Filmpackage/Billhistory.cshtml
+++ b/Netflixx/Views/Filmpackage/Billhistory.cshtml
@@ -356,6 +356,45 @@
                     <!-- Pagination placeholder -->
                 </div>
             </div>
+
+            <!-- Lịch sử mua phim bằng coins -->
+            <div class="history-section" style="margin-top:40px;">
+                <div class="history-header">
+                    <h2>Lịch sử mua phim bằng coins</h2>
+                </div>
+                <div class="billing-table-container">
+                    <table class="billing-table">
+                        <thead>
+                            <tr>
+                                <th>Ngày</th>
+                                <th>Tên phim</th>
+                                <th>Coins sử dụng</th>
+                                <th>Giá (VND)</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @if (Model.FilmPurchases.Any())
+                            {
+                                foreach (var p in Model.FilmPurchases)
+                                {
+                                    <tr>
+                                        <td>@p.PurchaseDate.ToString("dd/MM/yyyy")</td>
+                                        <td>@p.Film?.Title</td>
+                                        <td>@p.PointsUsed</td>
+                                        <td>@p.PricePaid.ToString("N0")</td>
+                                    </tr>
+                                }
+                            }
+                            else
+                            {
+                                <tr>
+                                    <td colspan="4" class="loading">Không có giao dịch mua phim</td>
+                                </tr>
+                            }
+                        </tbody>
+                    </table>
+                </div>
+            </div>
         </div>
     </main>
 </body>


### PR DESCRIPTION
## Summary
- include film purchases in BillHistoryViewModel
- query user's film purchases in the controller
- display coin-based film purchase history on Billhistory page

## Testing
- `dotnet build Netflixx.sln`

------
https://chatgpt.com/codex/tasks/task_e_6876508207488326b97c44915ab35f2a