### PR TITLE
Fix duplicated VNPAY transactions

### DIFF
--- a/Netflixx/Controllers/PaymentController.cs
+++ b/Netflixx/Controllers/PaymentController.cs
@@ -63,6 +63,8 @@ namespace Netflixx.Controllers
             var user = await _userManager.GetUserAsync(User);
             if (user != null)
             {
+                await using var transaction = await _context.Database.BeginTransactionAsync();
+
                 long.TryParse(amountStr, out var amount);
                 var coins = (int)(amount / 100);
 
@@ -90,6 +92,7 @@ namespace Netflixx.Controllers
                         .FirstOrDefaultAsync(pt => pt.ExternalTransactionRef == response.PaymentId);
                     if (existingTransaction != null)
                     {
+                        await transaction.RollbackAsync();
                         return View("RechargeResult", true);
                     }
 
@@ -134,6 +137,8 @@ namespace Netflixx.Controllers
 
                     await _context.SaveChangesAsync();
                 }
+
+                await transaction.CommitAsync();
             }
 
             return View("RechargeResult", success);

--- a/Netflixx/Models/PaymentTransactionsModel.cs
+++ b/Netflixx/Models/PaymentTransactionsModel.cs
@@ -1,8 +1,10 @@
 ﻿using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 namespace Netflixx.Models
 {
+    [Index(nameof(ExternalTransactionRef), IsUnique = true)]
     public class PaymentTransactionsModel
     {
         [Key]


### PR DESCRIPTION
## Summary
- ensure `PaymentTransactions` table enforces unique external refs
- guard against double processing in VNPAY callback by using database transactions

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687674e3bce883269e4cae28776348b1