### PR TITLE
Enable sortable Bill history view

### DIFF
--- a/Netflixx/Views/Filmpackage/Billhistory.cshtml
+++ b/Netflixx/Views/Filmpackage/Billhistory.cshtml
@@ -177,6 +177,15 @@
             .billing-table th {
                 background-color: #161a2b;
                 font-weight: 600;
+                cursor: pointer;
+            }
+
+            .billing-table th.sort-asc::after {
+                content: " \25B2"; /* Up arrow */
+            }
+
+            .billing-table th.sort-desc::after {
+                content: " \25BC"; /* Down arrow */
             }
 
             .billing-table tr:nth-child(even) {
@@ -381,7 +390,31 @@
         document.addEventListener('DOMContentLoaded', function () {
             const statusFilter = document.getElementById('statusFilter');
             const dateFilter = document.getElementById('dateFilter');
-            const rows = document.querySelectorAll('#transactionTable tbody tr');
+            const rows = Array.from(document.querySelectorAll('#transactionTable tbody tr'));
+            const headers = document.querySelectorAll('#transactionTable th');
+
+            function sortRows(index, order) {
+                const tbody = document.querySelector('#transactionTable tbody');
+                const sorted = rows.slice().sort((a, b) => {
+                    const aText = a.cells[index].textContent.trim();
+                    const bText = b.cells[index].textContent.trim();
+
+                    if (index === 0) {
+                        const [da, ma, ya] = aText.split('/');
+                        const [db, mb, yb] = bText.split('/');
+                        const dateA = new Date(ya, ma - 1, da);
+                        const dateB = new Date(yb, mb - 1, db);
+                        return dateA - dateB;
+                    }
+
+                    return aText.localeCompare(bText);
+                });
+
+                if (order === 'desc') sorted.reverse();
+
+                tbody.innerHTML = '';
+                sorted.forEach(r => tbody.appendChild(r));
+            }
 
             function filterRows() {
                 const statusValue = statusFilter.value.toLowerCase();
@@ -411,6 +444,17 @@
                     r.style.display = show ? '' : 'none';
                 });
             }
+
+            headers.forEach((h, i) => {
+                h.addEventListener('click', () => {
+                    const current = h.dataset.order === 'asc' ? 'desc' : 'asc';
+                    headers.forEach(head => head.classList.remove('sort-asc', 'sort-desc'));
+                    h.dataset.order = current;
+                    h.classList.add(current === 'asc' ? 'sort-asc' : 'sort-desc');
+                    sortRows(i, current);
+                    filterRows();
+                });
+            });
 
             if (statusFilter) statusFilter.addEventListener('change', filterRows);
             if (dateFilter) dateFilter.addEventListener('change', filterRows);


### PR DESCRIPTION
## Summary
- add cursor and arrow icons to table headers
- enable sorting by clicking the header

## Testing
- `npm run scss`
- `npm test` *(fails: Missing script)*
- `dotnet test Netflixx.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6876777e56fc8326872768441ba0c223