### PR TITLE
Add page info to bill history tables

### DIFF
--- a/Netflixx/Views/Filmpackage/Billhistory.cshtml
+++ b/Netflixx/Views/Filmpackage/Billhistory.cshtml
@@ -412,6 +412,8 @@
                 language: {
                     url: '//cdn.datatables.net/plug-ins/1.10.21/i18n/Vietnamese.json',
                     lengthMenu: 'Hiển thị _MENU_ mục',
+                    info: 'Hiển thị _START_ đến _END_ của _TOTAL_ mục (Trang _PAGE_ / _PAGES_)',
+                    infoEmpty: 'Không có mục để hiển thị',
                     paginate: { previous: 'Trước', next: 'Sau' }
                 },
                 dom: '<"top"lf>rt<"bottom"ip><"clear">'
@@ -422,6 +424,8 @@
                 language: {
                     url: '//cdn.datatables.net/plug-ins/1.10.21/i18n/Vietnamese.json',
                     lengthMenu: 'Hiển thị _MENU_ mục',
+                    info: 'Hiển thị _START_ đến _END_ của _TOTAL_ mục (Trang _PAGE_ / _PAGES_)',
+                    infoEmpty: 'Không có mục để hiển thị',
                     paginate: { previous: 'Trước', next: 'Sau' }
                 },
                 dom: '<"top"lf>rt<"bottom"ip><"clear">'


### PR DESCRIPTION
## Summary
- enhance bill history page tables with info about item range and page count

## Testing
- `dotnet build Netflixx/Netflixx.csproj -c Release`
- `dotnet test Netflixx.sln`

------
https://chatgpt.com/codex/tasks/task_e_68767ac51e548326899aabb470776216