### PR TITLE
Add custom page length dropdowns in bill history

### DIFF
--- a/Netflixx/Views/Filmpackage/Billhistory.cshtml
+++ b/Netflixx/Views/Filmpackage/Billhistory.cshtml
@@ -326,8 +326,16 @@
 
             <!-- Lịch sử giao dịch -->
             <div class="history-section">
-                <div class="history-header">
+                <div class="history-header d-flex justify-content-between align-items-center">
                     <h2>Giao dịch gói dịch vụ</h2>
+                    <div class="d-flex align-items-center">
+                        <span class="mr-2">Xem</span>
+                        <select class="form-control" style="width: 80px;" id="transactionsPageLength">
+                            <option value="5" selected>5</option>
+                            <option value="10">10</option>
+                            <option value="100">100</option>
+                        </select>
+                    </div>
                 </div>
                 <div class="billing-table-container">
                     <table class="billing-table" id="transactionsTable">
@@ -364,8 +372,16 @@
             </div>
 
             <div class="history-section" style="margin-top:40px;">
-                <div class="history-header">
+                <div class="history-header d-flex justify-content-between align-items-center">
                     <h2>Lịch sử mua phim</h2>
+                    <div class="d-flex align-items-center">
+                        <span class="mr-2">Xem</span>
+                        <select class="form-control" style="width: 80px;" id="purchasesPageLength">
+                            <option value="5" selected>5</option>
+                            <option value="10">10</option>
+                            <option value="100">100</option>
+                        </select>
+                    </div>
                 </div>
                 <div class="billing-table-container">
                     <table class="billing-table" id="purchasesTable">
@@ -406,25 +422,38 @@
     <script src="https://cdn.datatables.net/1.13.4/js/dataTables.bootstrap5.min.js"></script>
     <script>
         $(document).ready(function () {
-            $('#transactionsTable').DataTable({
-                pageLength: 10,
-                lengthMenu: [5, 10, 20, 50],
+            var transactionsTable = $('#transactionsTable').DataTable({
+                pageLength: parseInt($('#transactionsPageLength').val()),
+                lengthMenu: [5, 10, 100],
+                lengthChange: false,
                 language: {
                     url: '//cdn.datatables.net/plug-ins/1.10.21/i18n/Vietnamese.json',
                     lengthMenu: 'Hiển thị _MENU_ mục',
                     paginate: { previous: 'Trước', next: 'Sau' }
                 },
-                dom: '<"top"lf>rt<"bottom"ip><"clear">'
+                dom: '<"top"f>rt<"bottom"ip><"clear">'
             });
-            $('#purchasesTable').DataTable({
-                pageLength: 10,
-                lengthMenu: [5, 10, 20, 50],
+
+            $('#transactionsPageLength').change(function () {
+                var len = parseInt($(this).val());
+                transactionsTable.page.len(len).draw();
+            });
+
+            var purchasesTable = $('#purchasesTable').DataTable({
+                pageLength: parseInt($('#purchasesPageLength').val()),
+                lengthMenu: [5, 10, 100],
+                lengthChange: false,
                 language: {
                     url: '//cdn.datatables.net/plug-ins/1.10.21/i18n/Vietnamese.json',
                     lengthMenu: 'Hiển thị _MENU_ mục',
                     paginate: { previous: 'Trước', next: 'Sau' }
                 },
-                dom: '<"top"lf>rt<"bottom"ip><"clear">'
+                dom: '<"top"f>rt<"bottom"ip><"clear">'
+            });
+
+            $('#purchasesPageLength').change(function () {
+                var len = parseInt($(this).val());
+                purchasesTable.page.len(len).draw();
             });
         });
     </script>


### PR DESCRIPTION
## Summary
- add custom page length dropdowns to bill history tables
- hook dropdowns to DataTables page length settings

## Testing
- `npm run scss`


------
https://chatgpt.com/codex/tasks/task_e_68767c859ef48326a38790d90c2bfa5f