### PR TITLE
Add transaction detail modal

### DIFF
--- a/Netflixx/Views/Filmpackage/Billhistory.cshtml
+++ b/Netflixx/Views/Filmpackage/Billhistory.cshtml
@@ -324,6 +324,7 @@
                                 <th>Trạng thái</th>
                                 <th>Số tiền</th>
                                 <th>Nhà cung cấp</th>
+                                <th></th>
                             </tr>
                         </thead>
                         <tbody>
@@ -337,12 +338,24 @@
                                         <td>@t.Status</td>
                                         <td>@t.Amount.ToString("N0") @t.Currency</td>
                                         <td>@t.Provider?.Name</td>
+                                        <td>
+                                            <button type="button" class="action-btn view-detail-btn"
+                                                    data-bs-toggle="modal" data-bs-target="#transactionDetailModal"
+                                                    data-date="@t.TransactionDate.ToString("dd/MM/yyyy")"
+                                                    data-ref="@t.ExternalTransactionRef"
+                                                    data-status="@t.Status"
+                                                    data-amount="@t.Amount.ToString("N0") @t.Currency"
+                                                    data-provider="@t.Provider?.Name"
+                                                    data-environment="@t.Environment?.Name">
+                                                Chi tiết
+                                            </button>
+                                        </td>
                                     </tr>
                                 }
                             }
                             else
                             {
-                                <tr><td colspan="5" class="loading">Không có giao dịch nào</td></tr>
+                                <tr><td colspan="6" class="loading">Không có giao dịch nào</td></tr>
                             }
                         </tbody>
                     </table>
@@ -401,6 +414,29 @@
             </div>
 
         </div>
+
+        <div class="modal fade" id="transactionDetailModal" tabindex="-1" aria-hidden="true">
+            <div class="modal-dialog">
+                <div class="modal-content bg-dark text-white">
+                    <div class="modal-header">
+                        <h5 class="modal-title">Chi tiết giao dịch</h5>
+                        <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal"></button>
+                    </div>
+                    <div class="modal-body">
+                        <p><strong>Ngày:</strong> <span id="tdDate"></span></p>
+                        <p><strong>Mã giao dịch:</strong> <span id="tdRef"></span></p>
+                        <p><strong>Trạng thái:</strong> <span id="tdStatus"></span></p>
+                        <p><strong>Số tiền:</strong> <span id="tdAmount"></span></p>
+                        <p><strong>Nhà cung cấp:</strong> <span id="tdProvider"></span></p>
+                        <p><strong>Môi trường:</strong> <span id="tdEnv"></span></p>
+                    </div>
+                    <div class="modal-footer">
+                        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Đóng</button>
+                    </div>
+                </div>
+            </div>
+        </div>
+
     </main>
 @section Scripts {
     <script src="https://cdn.datatables.net/1.13.4/js/jquery.dataTables.min.js"></script>
@@ -474,6 +510,16 @@
 
             $('#purchasesSearch').on('keyup change', function () {
                 purchasesTable.column(1).search(this.value).draw();
+            });
+
+            $('body').on('click', '.view-detail-btn', function () {
+                var btn = $(this);
+                $('#tdDate').text(btn.data('date'));
+                $('#tdRef').text(btn.data('ref'));
+                $('#tdStatus').text(btn.data('status'));
+                $('#tdAmount').text(btn.data('amount'));
+                $('#tdProvider').text(btn.data('provider'));
+                $('#tdEnv').text(btn.data('environment'));
             });
         });
     </script>


### PR DESCRIPTION
## Summary
- add view detail button to transaction history
- display transaction information in a modal

## Testing
- `dotnet build Netflixx/Netflixx.csproj -clp:ErrorsOnly`


------
https://chatgpt.com/codex/tasks/task_e_687755c51e308326a529424103867804