### PR TITLE
Add quick amount buttons on recharge page

### DIFF
--- a/Netflixx/Views/Payment/Recharge.cshtml
+++ b/Netflixx/Views/Payment/Recharge.cshtml
@@ -11,6 +11,15 @@
                 <label for="amount" class="form-label">Số tiền (VND)</label>
                 <input type="number" class="form-control bg-dark text-white border-secondary" id="amount" name="amount" required min="20000" />
             </div>
+            <div class="mb-3">
+                <label class="form-label">Hoặc chọn nhanh</label>
+                <div class="amount-suggestions d-flex flex-wrap gap-2">
+                    <button type="button" class="btn btn-outline-light amount-btn" data-value="50000">50.000</button>
+                    <button type="button" class="btn btn-outline-light amount-btn" data-value="100000">100.000</button>
+                    <button type="button" class="btn btn-outline-light amount-btn" data-value="200000">200.000</button>
+                    <button type="button" class="btn btn-outline-light amount-btn" data-value="500000">500.000</button>
+                </div>
+            </div>
             <button type="submit" class="btn btn-danger w-100">Thanh toán qua VNPAY</button>
         </form>
     </div>
@@ -18,4 +27,19 @@
 
 @section Styles {
     <link rel="stylesheet" href="~/css/recharge.css" />
+}
+
+@section Scripts {
+    <script>
+        document.addEventListener('DOMContentLoaded', function () {
+            const amountInput = document.getElementById('amount');
+            document.querySelectorAll('.amount-btn').forEach(function (btn) {
+                btn.addEventListener('click', function () {
+                    amountInput.value = this.dataset.value;
+                    document.querySelectorAll('.amount-btn').forEach(b => b.classList.remove('active'));
+                    this.classList.add('active');
+                });
+            });
+        });
+    </script>
 }

--- a/Netflixx/wwwroot/css/recharge.css
+++ b/Netflixx/wwwroot/css/recharge.css
@@ -31,3 +31,13 @@
 .result-icon {
     font-size: 4rem;
 }
+
+.amount-suggestions .amount-btn {
+    min-width: 100px;
+}
+
+.amount-suggestions .amount-btn.active {
+    background-color: #e50914;
+    border-color: #e50914;
+    color: #fff;
+}


### PR DESCRIPTION
## Summary
- show common recharge amounts as quick-select buttons
- style amount suggestions and add active state
- update recharge page script to fill input when button clicked

## Testing
- `npm run scss`
- `dotnet build Netflixx/Netflixx.csproj -clp:ErrorsOnly`


------
https://chatgpt.com/codex/tasks/task_e_68775a06d4cc832692fa7d65b5927539