### PR TITLE
Fix Billhistory modal

### DIFF
--- a/Netflixx/Views/Filmpackage/Billhistory.cshtml
+++ b/Netflixx/Views/Filmpackage/Billhistory.cshtml
@@ -524,8 +524,8 @@
                 purchasesTable.column(1).search(this.value).draw();
             });
 
-            $('body').on('click', '.view-detail-btn', function () {
-                var btn = $(this);
+            $('#transactionDetailModal').on('show.bs.modal', function (event) {
+                var btn = $(event.relatedTarget);
                 $('#tdId').text(btn.data('id'));
                 $('#tdDate').text(btn.data('date'));
                 $('#tdRef').text(btn.data('ref'));


### PR DESCRIPTION
## Summary
- populate transaction details when modal opens

## Testing
- `npm run scss` *(fails: sass not found)*
- `npm install`
- `npm run scss`

------
https://chatgpt.com/codex/tasks/task_e_68775aa8a4048326985262c4f0185718