### PR TITLE
Improve film package display

### DIFF
--- a/Netflixx/Controllers/FilmpackageController.cs
+++ b/Netflixx/Controllers/FilmpackageController.cs
@@ -23,6 +23,7 @@ namespace Netflixx.Controllers
         public async Task<IActionResult> Index()
         {
             var packages = await _context.Packages
+                .Include(p => p.PackageFilms)
                 .AsNoTracking()
                 .OrderBy(p => p.Name)
                 .ToListAsync();

--- a/Netflixx/Views/Filmpackage/Index.cshtml
+++ b/Netflixx/Views/Filmpackage/Index.cshtml
@@ -25,6 +25,7 @@
                     <div class="package-header">
                         <h2>@pkg.Name</h2>
                         <div class="price">@pkg.Price.ToString("N0") coins<span></span></div>
+                    <div class="film-count">Bao gồm @((pkg.PackageFilms != null) ? pkg.PackageFilms.Count : 0) phim</div>
                     </div>
                     @if (!string.IsNullOrEmpty(pkg.Description))
                     {

--- a/Netflixx/wwwroot/css/FPackage.css
+++ b/Netflixx/wwwroot/css/FPackage.css
@@ -1,4 +1,4 @@
-﻿﻿* {
+* {
     margin: 0;
     padding: 0;
     box-sizing: border-box;
@@ -106,6 +106,12 @@ main {
         font-size: 16px;
         font-weight: normal;
     }
+.film-count {
+    font-size: 14px;
+    color: #cccccc;
+    text-align: center;
+    margin-bottom: 10px;
+}
 
 .package-features {
     padding: 20px;


### PR DESCRIPTION
## Summary
- load film list with packages
- show the number of films per package on the package list
- clean stray BOM and add style for film count badge

## Testing
- `npm run scss`

------
https://chatgpt.com/codex/tasks/task_e_68775d889f448326b0dcc6b8979b1350