### PR TITLE
Add ShopSouvenir brand manager

### DIFF
--- a/Netflixx/Areas/ShopSouvenir/Controllers/BrandController.cs
+++ b/Netflixx/Areas/ShopSouvenir/Controllers/BrandController.cs
@@ -1,0 +1,140 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Netflixx.Models;
+using Netflixx.Repositories;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Netflixx.Areas.ShopSouvenir.Controllers
+{
+    [Area("ShopSouvenir")]
+    public class BrandController : Controller
+    {
+        private readonly DBContext _context;
+
+        public BrandController(DBContext context)
+        {
+            _context = context;
+        }
+
+        public async Task<IActionResult> Index()
+        {
+            var brands = await _context.BrandSous.ToListAsync();
+            return View(brands);
+        }
+
+        public IActionResult Create()
+        {
+            return View();
+        }
+
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> Create(BrandSouModel brand)
+        {
+            if (ModelState.IsValid)
+            {
+                _context.BrandSous.Add(brand);
+                await _context.SaveChangesAsync();
+                return RedirectToAction(nameof(Index));
+            }
+            return View(brand);
+        }
+
+        public async Task<IActionResult> Edit(int? id)
+        {
+            if (id == null)
+            {
+                return NotFound();
+            }
+
+            var brand = await _context.BrandSous.FindAsync(id);
+            if (brand == null)
+            {
+                return NotFound();
+            }
+            return View(brand);
+        }
+
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> Edit(int id, BrandSouModel brand)
+        {
+            if (id != brand.Id)
+            {
+                return NotFound();
+            }
+
+            if (ModelState.IsValid)
+            {
+                try
+                {
+                    _context.Update(brand);
+                    await _context.SaveChangesAsync();
+                }
+                catch (DbUpdateConcurrencyException)
+                {
+                    if (!BrandExists(brand.Id))
+                    {
+                        return NotFound();
+                    }
+                    else
+                    {
+                        throw;
+                    }
+                }
+                return RedirectToAction(nameof(Index));
+            }
+            return View(brand);
+        }
+
+        public async Task<IActionResult> Delete(int? id)
+        {
+            if (id == null)
+            {
+                return NotFound();
+            }
+
+            var brand = await _context.BrandSous
+                .FirstOrDefaultAsync(m => m.Id == id);
+            if (brand == null)
+            {
+                return NotFound();
+            }
+
+            return View(brand);
+        }
+
+        [HttpPost, ActionName("Delete")]
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> DeleteConfirmed(int id)
+        {
+            var brand = await _context.BrandSous.FindAsync(id);
+            if (brand != null)
+            {
+                _context.BrandSous.Remove(brand);
+                await _context.SaveChangesAsync();
+            }
+            return RedirectToAction(nameof(Index));
+        }
+
+        public async Task<IActionResult> Details(int? id)
+        {
+            if (id == null)
+            {
+                return NotFound();
+            }
+            var brand = await _context.BrandSous.FirstOrDefaultAsync(m => m.Id == id);
+            if (brand == null)
+            {
+                return NotFound();
+            }
+            return View(brand);
+        }
+
+        private bool BrandExists(int id)
+        {
+            return _context.BrandSous.Any(e => e.Id == id);
+        }
+    }
+}

--- a/Netflixx/Areas/ShopSouvenir/Manager/Views/Brand/Index.cshtml
+++ b/Netflixx/Areas/ShopSouvenir/Manager/Views/Brand/Index.cshtml
@@ -1,0 +1,131 @@
+@model IEnumerable<Netflixx.Models.BrandSouModel>
+@{
+    ViewData["Title"] = "Brand Management";
+}
+<style>
+    body {
+        background: #000;
+        color: #fff;
+        font-family: 'Segoe UI', sans-serif;
+        margin: 0;
+        padding: 0;
+    }
+    .container {
+        max-width: 1200px;
+        margin: 2rem auto;
+        padding: 1rem;
+    }
+    h1 {
+        color: #FF4081;
+        margin-bottom: 1.5rem;
+    }
+    .table {
+        width: 100%;
+        border-collapse: collapse;
+        margin-bottom: 1rem;
+    }
+    .table-bordered {
+        border: 1px solid #333;
+    }
+    .table-striped tbody tr:nth-of-type(odd) {
+        background-color: #111;
+    }
+    .table-striped tbody tr:nth-of-type(even) {
+        background-color: #1a1a1a;
+    }
+    .table th, .table td {
+        padding: 0.75rem;
+        vertical-align: middle;
+        border: 1px solid #333;
+    }
+    .table th {
+        background-color: #FF4081;
+        color: #fff;
+        font-weight: 600;
+    }
+    .btn {
+        display: inline-block;
+        font-weight: 400;
+        text-align: center;
+        white-space: nowrap;
+        vertical-align: middle;
+        user-select: none;
+        border: 1px solid transparent;
+        padding: 0.375rem 0.75rem;
+        font-size: 0.9rem;
+        line-height: 1.5;
+        border-radius: 0.25rem;
+        transition: all 0.15s ease-in-out;
+        text-decoration: none;
+    }
+    .btn-primary {
+        color: #fff;
+        background-color: #FF4081;
+        border-color: #FF4081;
+    }
+        .btn-primary:hover {
+            background-color: #E91E63;
+            border-color: #E91E63;
+        }
+    .btn-warning {
+        color: #212529;
+        background-color: #ffc107;
+        border-color: #ffc107;
+    }
+        .btn-warning:hover {
+            background-color: #e0a800;
+            border-color: #d39e00;
+        }
+    .btn-danger {
+        color: #fff;
+        background-color: #dc3545;
+        border-color: #dc3545;
+    }
+        .btn-danger:hover {
+            background-color: #c82333;
+            border-color: #bd2130;
+        }
+    .btn-sm {
+        padding: 0.25rem 0.5rem;
+        font-size: 0.875rem;
+        line-height: 1.5;
+        border-radius: 0.2rem;
+    }
+    .actions {
+        white-space: nowrap;
+    }
+        .actions a {
+            margin-right: 5px;
+        }
+        .actions a:last-child {
+            margin-right: 0;
+        }
+</style>
+<div class="container">
+    <h1>Brand Management</h1>
+    <p>
+        <a asp-action="Create" class="btn btn-primary">Create New Brand</a>
+    </p>
+    <table class="table table-bordered table-striped">
+        <thead>
+            <tr>
+                <th>Name</th>
+                <th>Description</th>
+                <th class="text-center">Actions</th>
+            </tr>
+        </thead>
+        <tbody>
+            @foreach (var brand in Model)
+            {
+                <tr>
+                    <td>@brand.Name</td>
+                    <td>@brand.Description</td>
+                    <td class="actions">
+                        <a asp-action="Edit" asp-route-id="@brand.Id" class="btn btn-warning btn-sm">Edit</a>
+                        <a asp-action="Delete" asp-route-id="@brand.Id" class="btn btn-danger btn-sm">Delete</a>
+                    </td>
+                </tr>
+            }
+        </tbody>
+    </table>
+</div>

--- a/Netflixx/Areas/ShopSouvenir/Views/Brand/Create.cshtml
+++ b/Netflixx/Areas/ShopSouvenir/Views/Brand/Create.cshtml
@@ -1,0 +1,91 @@
+@model Netflixx.Models.BrandSouModel
+@{
+    ViewData["Title"] = "Create Brand";
+}
+<style>
+    body {
+        background: #000;
+        color: #fff;
+        font-family: 'Segoe UI', sans-serif;
+        margin: 0;
+        padding: 0;
+    }
+    .container {
+        max-width: 600px;
+        margin: 2rem auto;
+        padding: 1rem;
+    }
+    h1 {
+        color: #FF4081;
+        margin-bottom: 1.5rem;
+    }
+    .form-group {
+        margin-bottom: 1rem;
+    }
+    .control-label {
+        font-weight: 600;
+        margin-bottom: 0.5rem;
+        display: block;
+    }
+    .form-control {
+        background-color: #1a1a1a;
+        color: #fff;
+        border: 1px solid #333;
+        border-radius: 0.25rem;
+        padding: 0.375rem 0.75rem;
+        font-size: 0.9rem;
+    }
+    .form-control:focus {
+        border-color: #FF4081;
+        box-shadow: 0 0 0 0.2rem rgba(255, 64, 129, 0.25);
+    }
+    .text-danger {
+        color: #FF5252 !important;
+    }
+    .btn {
+        display: inline-block;
+        font-weight: 400;
+        text-align: center;
+        white-space: nowrap;
+        vertical-align: middle;
+        user-select: none;
+        border: 1px solid transparent;
+        padding: 0.375rem 0.75rem;
+        font-size: 0.9rem;
+        line-height: 1.5;
+        border-radius: 0.25rem;
+        transition: all 0.15s ease-in-out;
+        text-decoration: none;
+    }
+    .btn-primary {
+        color: #fff;
+        background-color: #FF4081;
+        border-color: #FF4081;
+    }
+        .btn-primary:hover {
+            background-color: #E91E63;
+            border-color: #E91E63;
+        }
+    .btn-secondary {
+        color: #fff;
+        background-color: #6c757d;
+        border-color: #6c757d;
+    }
+</style>
+<div class="container">
+    <h1>Create Brand</h1>
+    <form asp-action="Create" method="post">
+        <div class="form-group">
+            <label asp-for="Name" class="control-label"></label>
+            <input asp-for="Name" class="form-control" />
+            <span asp-validation-for="Name" class="text-danger"></span>
+        </div>
+        <div class="form-group">
+            <label asp-for="Description" class="control-label"></label>
+            <textarea asp-for="Description" class="form-control"></textarea>
+            <span asp-validation-for="Description" class="text-danger"></span>
+        </div>
+        <button type="submit" class="btn btn-primary">Create</button>
+        <a asp-action="Index" class="btn btn-secondary">Back to List</a>
+    </form>
+</div>

--- a/Netflixx/Areas/ShopSouvenir/Views/Brand/Delete.cshtml
+++ b/Netflixx/Areas/ShopSouvenir/Views/Brand/Delete.cshtml
@@ -1,0 +1,17 @@
+@model Netflixx.Models.BrandSouModel
+@{
+    ViewData["Title"] = "Delete Brand";
+}
+<div class="container">
+    <h1>Delete Brand</h1>
+    <h3>Are you sure you want to delete this?</h3>
+    <div>
+        <h4>@Model.Name</h4>
+        <p>@Model.Description</p>
+    </div>
+    <form asp-action="Delete" method="post">
+        <input type="hidden" asp-for="Id" />
+        <button type="submit" class="btn btn-danger">Delete</button>
+        <a asp-action="Index" class="btn btn-secondary">Back to List</a>
+    </form>
+</div>

--- a/Netflixx/Areas/ShopSouvenir/Views/Brand/Details.cshtml
+++ b/Netflixx/Areas/ShopSouvenir/Views/Brand/Details.cshtml
@@ -1,0 +1,15 @@
+@model Netflixx.Models.BrandSouModel
+@{
+    ViewData["Title"] = "Brand Details";
+}
+<div class="container">
+    <h1>Brand Details</h1>
+    <dl class="row">
+        <dt class="col-sm-2">Name</dt>
+        <dd class="col-sm-10">@Model.Name</dd>
+        <dt class="col-sm-2">Description</dt>
+        <dd class="col-sm-10">@Model.Description</dd>
+    </dl>
+    <a asp-action="Edit" asp-route-id="@Model.Id" class="btn btn-primary">Edit</a>
+    <a asp-action="Index" class="btn btn-secondary">Back to List</a>
+</div>

--- a/Netflixx/Areas/ShopSouvenir/Views/Brand/Edit.cshtml
+++ b/Netflixx/Areas/ShopSouvenir/Views/Brand/Edit.cshtml
@@ -1,0 +1,92 @@
+@model Netflixx.Models.BrandSouModel
+@{
+    ViewData["Title"] = "Edit Brand";
+}
+<style>
+    body {
+        background: #000;
+        color: #fff;
+        font-family: 'Segoe UI', sans-serif;
+        margin: 0;
+        padding: 0;
+    }
+    .container {
+        max-width: 600px;
+        margin: 2rem auto;
+        padding: 1rem;
+    }
+    h1 {
+        color: #FF4081;
+        margin-bottom: 1.5rem;
+    }
+    .form-group {
+        margin-bottom: 1rem;
+    }
+    .control-label {
+        font-weight: 600;
+        margin-bottom: 0.5rem;
+        display: block;
+    }
+    .form-control {
+        background-color: #1a1a1a;
+        color: #fff;
+        border: 1px solid #333;
+        border-radius: 0.25rem;
+        padding: 0.375rem 0.75rem;
+        font-size: 0.9rem;
+    }
+    .form-control:focus {
+        border-color: #FF4081;
+        box-shadow: 0 0 0 0.2rem rgba(255, 64, 129, 0.25);
+    }
+    .text-danger {
+        color: #FF5252 !important;
+    }
+    .btn {
+        display: inline-block;
+        font-weight: 400;
+        text-align: center;
+        white-space: nowrap;
+        vertical-align: middle;
+        user-select: none;
+        border: 1px solid transparent;
+        padding: 0.375rem 0.75rem;
+        font-size: 0.9rem;
+        line-height: 1.5;
+        border-radius: 0.25rem;
+        transition: all 0.15s ease-in-out;
+        text-decoration: none;
+    }
+    .btn-primary {
+        color: #fff;
+        background-color: #FF4081;
+        border-color: #FF4081;
+    }
+        .btn-primary:hover {
+            background-color: #E91E63;
+            border-color: #E91E63;
+        }
+    .btn-secondary {
+        color: #fff;
+        background-color: #6c757d;
+        border-color: #6c757d;
+    }
+</style>
+<div class="container">
+    <h1>Edit Brand</h1>
+    <form asp-action="Edit" method="post">
+        <input type="hidden" asp-for="Id" />
+        <div class="form-group">
+            <label asp-for="Name" class="control-label"></label>
+            <input asp-for="Name" class="form-control" />
+            <span asp-validation-for="Name" class="text-danger"></span>
+        </div>
+        <div class="form-group">
+            <label asp-for="Description" class="control-label"></label>
+            <textarea asp-for="Description" class="form-control"></textarea>
+            <span asp-validation-for="Description" class="text-danger"></span>
+        </div>
+        <button type="submit" class="btn btn-primary">Save</button>
+        <a asp-action="Index" class="btn btn-secondary">Back to List</a>
+    </form>
+</div>

--- a/Netflixx/Areas/ShopSouvenir/Views/Brand/Index.cshtml
+++ b/Netflixx/Areas/ShopSouvenir/Views/Brand/Index.cshtml
@@ -1,0 +1,131 @@
+@model IEnumerable<Netflixx.Models.BrandSouModel>
+@{
+    ViewData["Title"] = "Brand Management";
+}
+<style>
+    body {
+        background: #000;
+        color: #fff;
+        font-family: 'Segoe UI', sans-serif;
+        margin: 0;
+        padding: 0;
+    }
+    .container {
+        max-width: 1200px;
+        margin: 2rem auto;
+        padding: 1rem;
+    }
+    h1 {
+        color: #FF4081;
+        margin-bottom: 1.5rem;
+    }
+    .table {
+        width: 100%;
+        border-collapse: collapse;
+        margin-bottom: 1rem;
+    }
+    .table-bordered {
+        border: 1px solid #333;
+    }
+    .table-striped tbody tr:nth-of-type(odd) {
+        background-color: #111;
+    }
+    .table-striped tbody tr:nth-of-type(even) {
+        background-color: #1a1a1a;
+    }
+    .table th, .table td {
+        padding: 0.75rem;
+        vertical-align: middle;
+        border: 1px solid #333;
+    }
+    .table th {
+        background-color: #FF4081;
+        color: #fff;
+        font-weight: 600;
+    }
+    .btn {
+        display: inline-block;
+        font-weight: 400;
+        text-align: center;
+        white-space: nowrap;
+        vertical-align: middle;
+        user-select: none;
+        border: 1px solid transparent;
+        padding: 0.375rem 0.75rem;
+        font-size: 0.9rem;
+        line-height: 1.5;
+        border-radius: 0.25rem;
+        transition: all 0.15s ease-in-out;
+        text-decoration: none;
+    }
+    .btn-primary {
+        color: #fff;
+        background-color: #FF4081;
+        border-color: #FF4081;
+    }
+        .btn-primary:hover {
+            background-color: #E91E63;
+            border-color: #E91E63;
+        }
+    .btn-warning {
+        color: #212529;
+        background-color: #ffc107;
+        border-color: #ffc107;
+    }
+        .btn-warning:hover {
+            background-color: #e0a800;
+            border-color: #d39e00;
+        }
+    .btn-danger {
+        color: #fff;
+        background-color: #dc3545;
+        border-color: #dc3545;
+    }
+        .btn-danger:hover {
+            background-color: #c82333;
+            border-color: #bd2130;
+        }
+    .btn-sm {
+        padding: 0.25rem 0.5rem;
+        font-size: 0.875rem;
+        line-height: 1.5;
+        border-radius: 0.2rem;
+    }
+    .actions {
+        white-space: nowrap;
+    }
+        .actions a {
+            margin-right: 5px;
+        }
+        .actions a:last-child {
+            margin-right: 0;
+        }
+</style>
+<div class="container">
+    <h1>Brand Management</h1>
+    <p>
+        <a asp-action="Create" class="btn btn-primary">Create New Brand</a>
+    </p>
+    <table class="table table-bordered table-striped">
+        <thead>
+            <tr>
+                <th>Name</th>
+                <th>Description</th>
+                <th class="text-center">Actions</th>
+            </tr>
+        </thead>
+        <tbody>
+            @foreach (var brand in Model)
+            {
+                <tr>
+                    <td>@brand.Name</td>
+                    <td>@brand.Description</td>
+                    <td class="actions">
+                        <a asp-action="Edit" asp-route-id="@brand.Id" class="btn btn-warning btn-sm">Edit</a>
+                        <a asp-action="Delete" asp-route-id="@brand.Id" class="btn btn-danger btn-sm">Delete</a>
+                    </td>
+                </tr>
+            }
+        </tbody>
+    </table>
+</div>

--- a/Netflixx/Areas/ShopSouvenir/Views/Shared/_LayoutManager.cshtml
+++ b/Netflixx/Areas/ShopSouvenir/Views/Shared/_LayoutManager.cshtml
@@ -126,6 +126,9 @@
             <a href="/ShopSouvenir/Categories" class="nav-link">
                 <i class="fas fa-tags"></i> Danh mục
             </a>
+            <a href="/ShopSouvenir/Brand" class="nav-link">
+                <i class="fas fa-industry"></i> Thương hiệu
+            </a>
         </div>
     </div>
 


### PR DESCRIPTION
## Summary
- add `BrandController` for ShopSouvenir
- create CRUD pages for brand management
- add manager view for brand listing
- link brand section in ShopSouvenir manager layout

## Testing
- `npm run scss` *(fails initially, installed sass, then succeeded)*

------
https://chatgpt.com/codex/tasks/task_e_68776eaf09d48326b506510069bf8f23