### PR TITLE
Add brand manager page for ShopSouvenir

### DIFF
--- a/Netflixx/Areas/ShopSouvenir/Controllers/BrandController.cs
+++ b/Netflixx/Areas/ShopSouvenir/Controllers/BrandController.cs
@@ -1,0 +1,150 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Netflixx.Models;
+using Netflixx.Repositories;
+using System.Threading.Tasks;
+
+namespace Netflixx.Areas.ShopSouvenir.Controllers
+{
+    [Area("ShopSouvenir")]
+    public class BrandController : Controller
+    {
+        private readonly DBContext _context;
+
+        public BrandController(DBContext context)
+        {
+            _context = context;
+        }
+
+        // GET: ShopSouvenir/Brand
+        public async Task<IActionResult> Index()
+        {
+            var brands = await _context.BrandSous.ToListAsync();
+            return View(brands);
+        }
+
+        // GET: ShopSouvenir/Brand/Details/5
+        public async Task<IActionResult> Details(int? id)
+        {
+            if (id == null)
+            {
+                return NotFound();
+            }
+
+            var brand = await _context.BrandSous
+                .FirstOrDefaultAsync(m => m.Id == id);
+            if (brand == null)
+            {
+                return NotFound();
+            }
+
+            return View(brand);
+        }
+
+        // GET: ShopSouvenir/Brand/Create
+        public IActionResult Create()
+        {
+            return View();
+        }
+
+        // POST: ShopSouvenir/Brand/Create
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> Create([Bind("Id,Name,Description")] BrandSouModel brand)
+        {
+            if (ModelState.IsValid)
+            {
+                _context.Add(brand);
+                await _context.SaveChangesAsync();
+                return RedirectToAction(nameof(Index));
+            }
+            return View(brand);
+        }
+
+        // GET: ShopSouvenir/Brand/Edit/5
+        public async Task<IActionResult> Edit(int? id)
+        {
+            if (id == null)
+            {
+                return NotFound();
+            }
+
+            var brand = await _context.BrandSous.FindAsync(id);
+            if (brand == null)
+            {
+                return NotFound();
+            }
+            return View(brand);
+        }
+
+        // POST: ShopSouvenir/Brand/Edit/5
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> Edit(int id, [Bind("Id,Name,Description")] BrandSouModel brand)
+        {
+            if (id != brand.Id)
+            {
+                return NotFound();
+            }
+
+            if (ModelState.IsValid)
+            {
+                try
+                {
+                    _context.Update(brand);
+                    await _context.SaveChangesAsync();
+                }
+                catch (DbUpdateConcurrencyException)
+                {
+                    if (!BrandExists(brand.Id))
+                    {
+                        return NotFound();
+                    }
+                    else
+                    {
+                        throw;
+                    }
+                }
+                return RedirectToAction(nameof(Index));
+            }
+            return View(brand);
+        }
+
+        // GET: ShopSouvenir/Brand/Delete/5
+        public async Task<IActionResult> Delete(int? id)
+        {
+            if (id == null)
+            {
+                return NotFound();
+            }
+
+            var brand = await _context.BrandSous
+                .FirstOrDefaultAsync(m => m.Id == id);
+            if (brand == null)
+            {
+                return NotFound();
+            }
+
+            return View(brand);
+        }
+
+        // POST: ShopSouvenir/Brand/Delete/5
+        [HttpPost, ActionName("Delete")]
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> DeleteConfirmed(int id)
+        {
+            var brand = await _context.BrandSous.FindAsync(id);
+            if (brand != null)
+            {
+                _context.BrandSous.Remove(brand);
+                await _context.SaveChangesAsync();
+            }
+            return RedirectToAction(nameof(Index));
+        }
+
+        private bool BrandExists(int id)
+        {
+            return _context.BrandSous.Any(e => e.Id == id);
+        }
+    }
+}

--- a/Netflixx/Areas/ShopSouvenir/Views/Brand/Create.cshtml
+++ b/Netflixx/Areas/ShopSouvenir/Views/Brand/Create.cshtml
@@ -1,0 +1,27 @@
+@model Netflixx.Models.BrandSouModel
+@{
+    ViewData["Title"] = "Thêm Thương hiệu";
+}
+<div class="container">
+    <h1>Thêm Thương hiệu</h1>
+    <form asp-action="Create">
+        <div asp-validation-summary="ModelOnly" class="text-danger"></div>
+        <div class="form-group">
+            <label asp-for="Name" class="control-label"></label>
+            <input asp-for="Name" class="form-control" />
+            <span asp-validation-for="Name" class="text-danger"></span>
+        </div>
+        <div class="form-group">
+            <label asp-for="Description" class="control-label"></label>
+            <textarea asp-for="Description" class="form-control"></textarea>
+            <span asp-validation-for="Description" class="text-danger"></span>
+        </div>
+        <div class="form-group mt-3">
+            <input type="submit" value="Thêm" class="btn btn-primary" />
+            <a asp-action="Index" class="btn btn-secondary">Quay lại</a>
+        </div>
+    </form>
+</div>
+@section Scripts {
+    @{await Html.RenderPartialAsync("_ValidationScriptsPartial");}
+}

--- a/Netflixx/Areas/ShopSouvenir/Views/Brand/Delete.cshtml
+++ b/Netflixx/Areas/ShopSouvenir/Views/Brand/Delete.cshtml
@@ -1,0 +1,23 @@
+@model Netflixx.Models.BrandSouModel
+@{
+    ViewData["Title"] = "Xóa Thương hiệu";
+}
+<div class="container">
+    <h1>Xóa Thương hiệu</h1>
+    <h3>Bạn có chắc muốn xóa thương hiệu này?</h3>
+    <div>
+        <h4>@Model.Name</h4>
+        <hr />
+        <dl class="row">
+            <dt class="col-sm-2">Tên</dt>
+            <dd class="col-sm-10">@Model.Name</dd>
+            <dt class="col-sm-2">Mô tả</dt>
+            <dd class="col-sm-10">@Model.Description</dd>
+        </dl>
+    </div>
+    <form asp-action="Delete" method="post">
+        <input type="hidden" asp-for="Id" />
+        <input type="submit" value="Xóa" class="btn btn-danger" />
+        <a asp-action="Index" class="btn btn-secondary">Quay lại</a>
+    </form>
+</div>

--- a/Netflixx/Areas/ShopSouvenir/Views/Brand/Details.cshtml
+++ b/Netflixx/Areas/ShopSouvenir/Views/Brand/Details.cshtml
@@ -1,0 +1,21 @@
+@model Netflixx.Models.BrandSouModel
+@{
+    ViewData["Title"] = "Chi tiết Thương hiệu";
+}
+<div class="container">
+    <h1>Chi tiết Thương hiệu</h1>
+    <div>
+        <h4>@Model.Name</h4>
+        <hr />
+        <dl class="row">
+            <dt class="col-sm-2">Tên</dt>
+            <dd class="col-sm-10">@Model.Name</dd>
+            <dt class="col-sm-2">Mô tả</dt>
+            <dd class="col-sm-10">@Model.Description</dd>
+        </dl>
+    </div>
+    <div>
+        <a asp-action="Edit" asp-route-id="@Model.Id" class="btn btn-primary">Sửa</a>
+        <a asp-action="Index" class="btn btn-secondary">Quay lại</a>
+    </div>
+</div>

--- a/Netflixx/Areas/ShopSouvenir/Views/Brand/Edit.cshtml
+++ b/Netflixx/Areas/ShopSouvenir/Views/Brand/Edit.cshtml
@@ -1,0 +1,28 @@
+@model Netflixx.Models.BrandSouModel
+@{
+    ViewData["Title"] = "Chỉnh sửa Thương hiệu";
+}
+<div class="container">
+    <h1>Chỉnh sửa Thương hiệu</h1>
+    <form asp-action="Edit">
+        <input type="hidden" asp-for="Id" />
+        <div asp-validation-summary="ModelOnly" class="text-danger"></div>
+        <div class="form-group">
+            <label asp-for="Name" class="control-label"></label>
+            <input asp-for="Name" class="form-control" />
+            <span asp-validation-for="Name" class="text-danger"></span>
+        </div>
+        <div class="form-group">
+            <label asp-for="Description" class="control-label"></label>
+            <textarea asp-for="Description" class="form-control"></textarea>
+            <span asp-validation-for="Description" class="text-danger"></span>
+        </div>
+        <div class="form-group mt-3">
+            <input type="submit" value="Lưu" class="btn btn-primary" />
+            <a asp-action="Index" class="btn btn-secondary">Quay lại</a>
+        </div>
+    </form>
+</div>
+@section Scripts {
+    @{await Html.RenderPartialAsync("_ValidationScriptsPartial");}
+}

--- a/Netflixx/Areas/ShopSouvenir/Views/Brand/Index.cshtml
+++ b/Netflixx/Areas/ShopSouvenir/Views/Brand/Index.cshtml
@@ -1,0 +1,47 @@
+@model IEnumerable<Netflixx.Models.BrandSouModel>
+@{
+    ViewData["Title"] = "Quản lý Thương hiệu";
+}
+@section Styles {
+    <link rel="stylesheet" href="https://cdn.datatables.net/1.13.4/css/dataTables.bootstrap5.min.css" />
+}
+<div class="container">
+    <h1>Quản lý Thương hiệu</h1>
+    <p>
+        <a asp-action="Create" class="btn btn-primary">Thêm thương hiệu</a>
+    </p>
+    <table id="brandsTable" class="table table-bordered table-striped">
+        <thead>
+            <tr>
+                <th>Tên thương hiệu</th>
+                <th>Mô tả</th>
+                <th class="text-center">Thao tác</th>
+            </tr>
+        </thead>
+        <tbody>
+@foreach (var item in Model)
+{
+            <tr>
+                <td>@item.Name</td>
+                <td>@item.Description</td>
+                <td class="text-center">
+                    <a asp-action="Edit" asp-route-id="@item.Id" class="btn btn-warning btn-sm">Sửa</a>
+                    <a asp-action="Details" asp-route-id="@item.Id" class="btn btn-info btn-sm">Chi tiết</a>
+                    <a asp-action="Delete" asp-route-id="@item.Id" class="btn btn-danger btn-sm">Xóa</a>
+                </td>
+            </tr>
+}
+        </tbody>
+    </table>
+</div>
+@section Scripts {
+    <script src="https://cdn.datatables.net/1.13.4/js/jquery.dataTables.min.js"></script>
+    <script src="https://cdn.datatables.net/1.13.4/js/dataTables.bootstrap5.min.js"></script>
+    <script>
+        $(document).ready(function () {
+            $('#brandsTable').DataTable({
+                language: { url: '//cdn.datatables.net/plug-ins/1.13.4/i18n/vi.json' }
+            });
+        });
+    </script>
+}

--- a/Netflixx/Areas/ShopSouvenir/Views/Shared/_LayoutManager.cshtml
+++ b/Netflixx/Areas/ShopSouvenir/Views/Shared/_LayoutManager.cshtml
@@ -126,6 +126,9 @@
             <a href="/ShopSouvenir/Categories" class="nav-link">
                 <i class="fas fa-tags"></i> Danh mục
             </a>
+            <a href="/ShopSouvenir/Brand" class="nav-link">
+                <i class="fas fa-industry"></i> Thương hiệu
+            </a>
         </div>
     </div>
 


### PR DESCRIPTION
## Summary
- rename BrandSou pages to Brand to match manager routes
- add `BrandController` for CRUD actions
- add menu link to manage brands

## Testing
- `dotnet build Netflixx.sln`


------
https://chatgpt.com/codex/tasks/task_e_687779033e7483269a71fa3a5498b074