### PR TITLE
Update ShopSouvenir brand model

### DIFF
--- a/Netflixx/Areas/ShopSouvenir/Views/Brand/Create.cshtml
+++ b/Netflixx/Areas/ShopSouvenir/Views/Brand/Create.cshtml
@@ -12,6 +12,16 @@
             <span asp-validation-for="Name" class="text-danger"></span>
         </div>
         <div class="form-group">
+            <label asp-for="Country" class="control-label"></label>
+            <input asp-for="Country" class="form-control" />
+            <span asp-validation-for="Country" class="text-danger"></span>
+        </div>
+        <div class="form-group">
+            <label asp-for="Website" class="control-label"></label>
+            <input asp-for="Website" class="form-control" />
+            <span asp-validation-for="Website" class="text-danger"></span>
+        </div>
+        <div class="form-group">
             <label asp-for="Description" class="control-label"></label>
             <textarea asp-for="Description" class="form-control"></textarea>
             <span asp-validation-for="Description" class="text-danger"></span>

--- a/Netflixx/Areas/ShopSouvenir/Views/Brand/Delete.cshtml
+++ b/Netflixx/Areas/ShopSouvenir/Views/Brand/Delete.cshtml
@@ -11,6 +11,8 @@
         <dl class="row">
             <dt class="col-sm-2">Tên</dt>
             <dd class="col-sm-10">@Model.Name</dd>
+            <dt class="col-sm-2">Quốc gia</dt>
+            <dd class="col-sm-10">@Model.Country</dd>
             <dt class="col-sm-2">Mô tả</dt>
             <dd class="col-sm-10">@Model.Description</dd>
         </dl>

--- a/Netflixx/Areas/ShopSouvenir/Views/Brand/Details.cshtml
+++ b/Netflixx/Areas/ShopSouvenir/Views/Brand/Details.cshtml
@@ -10,6 +10,10 @@
         <dl class="row">
             <dt class="col-sm-2">Tên</dt>
             <dd class="col-sm-10">@Model.Name</dd>
+            <dt class="col-sm-2">Quốc gia</dt>
+            <dd class="col-sm-10">@Model.Country</dd>
+            <dt class="col-sm-2">Website</dt>
+            <dd class="col-sm-10">@Model.Website</dd>
             <dt class="col-sm-2">Mô tả</dt>
             <dd class="col-sm-10">@Model.Description</dd>
         </dl>

--- a/Netflixx/Areas/ShopSouvenir/Views/Brand/Edit.cshtml
+++ b/Netflixx/Areas/ShopSouvenir/Views/Brand/Edit.cshtml
@@ -13,6 +13,16 @@
             <span asp-validation-for="Name" class="text-danger"></span>
         </div>
         <div class="form-group">
+            <label asp-for="Country" class="control-label"></label>
+            <input asp-for="Country" class="form-control" />
+            <span asp-validation-for="Country" class="text-danger"></span>
+        </div>
+        <div class="form-group">
+            <label asp-for="Website" class="control-label"></label>
+            <input asp-for="Website" class="form-control" />
+            <span asp-validation-for="Website" class="text-danger"></span>
+        </div>
+        <div class="form-group">
             <label asp-for="Description" class="control-label"></label>
             <textarea asp-for="Description" class="form-control"></textarea>
             <span asp-validation-for="Description" class="text-danger"></span>

--- a/Netflixx/Areas/ShopSouvenir/Views/Brand/Index.cshtml
+++ b/Netflixx/Areas/ShopSouvenir/Views/Brand/Index.cshtml
@@ -14,6 +14,7 @@
         <thead>
             <tr>
                 <th>Tên thương hiệu</th>
+                <th>Quốc gia</th>
                 <th>Mô tả</th>
                 <th class="text-center">Thao tác</th>
             </tr>
@@ -23,6 +24,7 @@
 {
             <tr>
                 <td>@item.Name</td>
+                <td>@item.Country</td>
                 <td>@item.Description</td>
                 <td class="text-center">
                     <a asp-action="Edit" asp-route-id="@item.Id" class="btn btn-warning btn-sm">Sửa</a>

--- a/Netflixx/Models/BrandHistory.cs
+++ b/Netflixx/Models/BrandHistory.cs
@@ -1,0 +1,25 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace Netflixx.Models
+{
+    public class BrandHistory
+    {
+        [Key]
+        public int Id { get; set; }
+        public int? BrandId { get; set; }
+
+        [StringLength(100)]
+        public string? BrandName { get; set; }
+
+        [StringLength(20)]
+        public string Action { get; set; } = string.Empty;
+
+        public string? Details { get; set; }
+        public DateTime Timestamp { get; set; }
+
+        [ForeignKey("BrandId")]
+        public BrandSouModel? Brand { get; set; }
+    }
+}

--- a/Netflixx/Models/BrandSouModel.cs
+++ b/Netflixx/Models/BrandSouModel.cs
@@ -1,19 +1,73 @@
-﻿using Netflixx.Models.Souvenir;
+using System;
+using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.AspNetCore.Http;
+using Netflixx.Models.Souvenir;
 
-    namespace Netflixx.Models
+namespace Netflixx.Models
+{
+    public class BrandSouModel
     {
-        public class BrandSouModel
-        {
-            [Key]
-            public int Id { get; set; }
+        [Key]
+        public int Id { get; set; }
 
-            [Required]
-            public string Name { get; set; }
+        [Required(ErrorMessage = "Tên là bắt buộc")]
+        [StringLength(100, ErrorMessage = "Tên không được vượt quá 100 ký tự")]
+        [Display(Name = "Tên thương hiệu")]
+        public string Name { get; set; } = null!;
 
-            public string Description { get; set; }
+        [StringLength(200)]
+        [Display(Name = "Website")]
+        [Url(ErrorMessage = "Vui lòng nhập URL hợp lệ")]
+        public string? Website { get; set; }
 
-            // Navigation property
-            public ICollection<ProductSouModel> Products { get; set; }
-        }
+        [Required(ErrorMessage = "Quốc gia là bắt buộc")]
+        [StringLength(50)]
+        [Display(Name = "Quốc gia")]
+        public string Country { get; set; } = null!;
+
+        [Display(Name = "Ngày thành lập")]
+        [DataType(DataType.Date)]
+        public DateTime? EstablishedDate { get; set; }
+
+        [StringLength(50)]
+        [Display(Name = "Tên viết tắt")]
+        public string? Alias { get; set; }
+
+        [StringLength(100)]
+        [Display(Name = "CEO")]
+        public string? CEO { get; set; }
+
+        [StringLength(200)]
+        [Display(Name = "Trụ sở chính")]
+        public string? Headquarters { get; set; }
+
+        [StringLength(500)]
+        [Display(Name = "Mô tả")]
+        public string? Description { get; set; }
+
+        [StringLength(300)]
+        [Display(Name = "Logo")]
+        public string? LogoUrl { get; set; }
+
+        [NotMapped]
+        [Display(Name = "Logo")]
+        public IFormFile? LogoFile { get; set; }
+
+        [Display(Name = "Đã xóa")]
+        public bool IsDeleted { get; set; } = false;
+
+        [Display(Name = "Thời gian xóa")]
+        public DateTime? DeletedAt { get; set; }
+
+        [Display(Name = "Ngày tạo")]
+        public DateTime CreatedAt { get; set; }
+
+        [Display(Name = "Ngày cập nhật")]
+        public DateTime UpdatedAt { get; set; }
+
+        public ICollection<ProductSouModel> Products { get; set; } = new List<ProductSouModel>();
+        public ICollection<BrandHistory> Histories { get; set; } = new List<BrandHistory>();
     }
+}

--- a/Netflixx/Repositories/DBContext.cs
+++ b/Netflixx/Repositories/DBContext.cs
@@ -43,6 +43,7 @@ namespace Netflixx.Repositories
         public virtual DbSet<DailyRevenueModel> DailyRevenue { get; set; }
         public virtual DbSet<ProductionManager> ProductionManagers { get; set; }
         public virtual DbSet<ProductionManagerHistory> ProductionManagerHistories { get; set; }
+        public virtual DbSet<BrandHistory> BrandHistories { get; set; }
 
         public virtual DbSet<LoginHistory> LoginHistory { get; set; }
         public virtual DbSet<FavoriteFilmsModel> FavoriteFilms { get; set; }
@@ -68,11 +69,29 @@ namespace Netflixx.Repositories
             modelBuilder.Entity<ProductionManagerHistory>()
                   .Property(h => h.Details)
                   .HasColumnType("nvarchar(max)");
+
+            modelBuilder.Entity<BrandSouModel>()
+                     .ToTable("BrandSous");
+            modelBuilder.Entity<BrandSouModel>()
+                     .Property(b => b.IsDeleted)
+                     .HasDefaultValue(false);
+            modelBuilder.Entity<BrandSouModel>()
+                     .Property(b => b.DeletedAt);
+            modelBuilder.Entity<BrandHistory>()
+                     .ToTable("BrandHistories");
+            modelBuilder.Entity<BrandHistory>()
+                     .HasOne(h => h.Brand)
+                     .WithMany(b => b.Histories)
+                     .HasForeignKey(h => h.BrandId)
+                     .OnDelete(DeleteBehavior.SetNull);
+            modelBuilder.Entity<BrandHistory>()
+                     .Property(h => h.Details)
+                     .HasColumnType("nvarchar(max)");
             modelBuilder.Entity<FilmsModel>()
-       .HasOne(f => f.ProductionManager)           
-       .WithMany(p => p.Films)                     
-       .HasForeignKey(f => f.ProductionManagerId)  
-       .OnDelete(DeleteBehavior.SetNull);         
+       .HasOne(f => f.ProductionManager)
+       .WithMany(p => p.Films)
+       .HasForeignKey(f => f.ProductionManagerId)
+       .OnDelete(DeleteBehavior.SetNull);
 
             base.OnModelCreating(modelBuilder);
             modelBuilder.Entity<ProductSouModel>()


### PR DESCRIPTION
## Summary
- expand `BrandSouModel` with fields similar to `ProductionManager`
- track brand history in new `BrandHistory` model
- wire up brand history and timestamps in `BrandController`
- include country and website fields in brand views
- configure `DBContext` for new brand history table

## Testing
- `dotnet build Netflixx/Netflixx.csproj -nologo`

------
https://chatgpt.com/codex/tasks/task_e_68777fd45d208326b07712fe5a3a48ea