### PR TITLE
Fix ShopSouvenir namespace error

### DIFF
--- a/Netflixx/Areas/ShopSouvenir/Controllers/ProductSouController.cs
+++ b/Netflixx/Areas/ShopSouvenir/Controllers/ProductSouController.cs
@@ -8,6 +8,7 @@ using Netflixx.Repositories;
 using System.Linq;
 using System.Text.Json;
 using System.Threading.Tasks;
+using System.IO;
 
 namespace Netflixx.Areas.ShopSouvenir.Controllers
 {


### PR DESCRIPTION
## Summary
- include `System.IO` namespace for file upload helpers

## Testing
- `dotnet build Netflixx/Netflixx.csproj -c Release`

------
https://chatgpt.com/codex/tasks/task_e_687782be3af083269e76f08ed1eb426f