### PR TITLE
Add BrandManager page

### DIFF
--- a/Netflixx/Areas/ShopSouvenir/Controllers/BrandController.cs
+++ b/Netflixx/Areas/ShopSouvenir/Controllers/BrandController.cs
@@ -22,6 +22,13 @@ namespace Netflixx.Areas.ShopSouvenir.Controllers
         }
 
         [HttpGet]
+        public async Task<IActionResult> Manager()
+        {
+            var brands = await _context.BrandSous.ToListAsync();
+            return View(brands);
+        }
+
+        [HttpGet]
         public IActionResult Add()
         {
             return View();

--- a/Netflixx/Areas/ShopSouvenir/Views/Brand/Manager.cshtml
+++ b/Netflixx/Areas/ShopSouvenir/Views/Brand/Manager.cshtml
@@ -1,0 +1,73 @@
+@model IEnumerable<Netflixx.Models.BrandSouModel>
+@{
+    ViewData["Title"] = "Brand Manager";
+    Layout = "_LayoutManager";
+}
+
+<div class="d-flex justify-content-between align-items-center mb-4">
+    <h3>@ViewData["Title"]</h3>
+    <a href="/ShopSouvenir/Brand/Add" class="btn btn-success">
+        <i class="fas fa-plus"></i> Thêm thương hiệu
+    </a>
+</div>
+
+@if (TempData["success"] != null)
+{
+    <div class="alert alert-success">@TempData["success"]</div>
+}
+@if (TempData["error"] != null)
+{
+    <div class="alert alert-danger">@TempData["error"]</div>
+}
+
+<div class="table-responsive">
+    <table class="table table-striped table-bordered" id="brandTable">
+        <thead class="thead-dark">
+            <tr>
+                <th>Mã brand</th>
+                <th>Tên brand</th>
+                <th>Mô tả</th>
+                <th>Hành động</th>
+            </tr>
+        </thead>
+        <tbody>
+            @foreach (var brand in Model)
+            {
+                <tr>
+                    <td>@brand.Id</td>
+                    <td>@brand.Name</td>
+                    <td>@brand.Description</td>
+                    <td>
+                        <div class="btn-group" role="group">
+                            <a asp-action="Edit" asp-route-BrandId="@brand.Id" class="btn btn-sm btn-warning">
+                                <i class="fas fa-edit"></i>
+                            </a>
+                            <a asp-action="Remove" asp-route-BrandId="@brand.Id" class="btn btn-sm btn-danger confirmDeletion">
+                                <i class="fas fa-trash"></i>
+                            </a>
+                        </div>
+                    </td>
+                </tr>
+            }
+        </tbody>
+    </table>
+</div>
+
+@section Scripts {
+    <script>
+        $(document).ready(function () {
+            $('.confirmDeletion').click(function () {
+                return confirm('Bạn có chắc chắn muốn xóa thương hiệu này?');
+            });
+
+            $('#brandTable').DataTable({
+                responsive: true,
+                language: {
+                    url: '//cdn.datatables.net/plug-ins/1.13.6/i18n/vi.json'
+                },
+                dom: '<"top"f>rt<"bottom"lip><"clear">',
+                pageLength: 10
+            });
+        });
+    </script>
+}

--- a/Netflixx/Areas/ShopSouvenir/Views/Shared/_LayoutManager.cshtml
+++ b/Netflixx/Areas/ShopSouvenir/Views/Shared/_LayoutManager.cshtml
@@ -11,6 +11,10 @@
     <!-- Bootstrap CSS -->
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet">
 
+    <!-- DataTables CSS -->
+    <link href="https://cdn.datatables.net/2.3.0/css/dataTables.dataTables.css" rel="stylesheet">
+    <link href="https://cdn.datatables.net/buttons/3.2.3/css/buttons.dataTables.css" rel="stylesheet">
+
     <!-- Custom styles -->
     <style>
         body {
@@ -126,6 +130,9 @@
             <a href="/ShopSouvenir/Categories" class="nav-link">
                 <i class="fas fa-tags"></i> Danh mục
             </a>
+            <a href="/ShopSouvenir/Brand/Manager" class="nav-link">
+                <i class="fas fa-copyright"></i> Thương hiệu
+            </a>
         </div>
     </div>
 
@@ -165,6 +172,14 @@
     <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script> <!-- Added Chart.js -->
+    <script src="//cdn.datatables.net/2.3.0/js/dataTables.min.js"></script>
+    <script src="https://cdn.datatables.net/buttons/3.2.3/js/dataTables.buttons.js"></script>
+    <script src="https://cdn.datatables.net/buttons/3.2.3/js/buttons.dataTables.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jszip/3.10.1/jszip.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/pdfmake/0.2.7/pdfmake.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/pdfmake/0.2.7/vfs_fonts.js"></script>
+    <script src="https://cdn.datatables.net/buttons/3.2.3/js/buttons.html5.min.js"></script>
+    <script src="https://cdn.datatables.net/buttons/3.2.3/js/buttons.print.min.js"></script>
 
     <script>
         $('#sidebarToggle').on('click', function () {


### PR DESCRIPTION
## Summary
- add navigation link for Brand manager
- add DataTables resources to manager layout
- implement `/ShopSouvenir/Brand/Manager` page to manage brands
- expose new Manager action in `BrandController`

## Testing
- `dotnet build Netflixx.sln`

------
https://chatgpt.com/codex/tasks/task_e_687788bb28e88326867ddde4fa4ebd19