### PR TITLE
Add BrandManager admin pages

### DIFF
--- a/Netflixx/Areas/ShopSouvenir/Controllers/BrandManagerController.cs
+++ b/Netflixx/Areas/ShopSouvenir/Controllers/BrandManagerController.cs
@@ -1,0 +1,146 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Netflixx.Models;
+using Netflixx.Repositories;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Netflixx.Areas.ShopSouvenir.Controllers
+{
+    [Area("ShopSouvenir")]
+    public class BrandManagerController : Controller
+    {
+        private readonly DBContext _context;
+
+        public BrandManagerController(DBContext context)
+        {
+            _context = context;
+        }
+
+        // GET: ShopSouvenir/BrandManager
+        public async Task<IActionResult> Index()
+        {
+            var list = await _context.BrandSous.AsNoTracking().ToListAsync();
+            return View(list);
+        }
+
+        // GET: ShopSouvenir/BrandManager/Details/5
+        public async Task<IActionResult> Details(int? id)
+        {
+            if (id == null)
+            {
+                return NotFound();
+            }
+            var brand = await _context.BrandSous.FirstOrDefaultAsync(b => b.Id == id);
+            if (brand == null)
+            {
+                return NotFound();
+            }
+            return View(brand);
+        }
+
+        // GET: ShopSouvenir/BrandManager/Create
+        public IActionResult Create()
+        {
+            return View();
+        }
+
+        // POST: ShopSouvenir/BrandManager/Create
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> Create([Bind("Id,Name,Description")] BrandSouModel brand)
+        {
+            if (ModelState.IsValid)
+            {
+                _context.Add(brand);
+                await _context.SaveChangesAsync();
+                TempData["SuccessMessage"] = "Thêm thương hiệu thành công!";
+                return RedirectToAction(nameof(Index));
+            }
+            return View(brand);
+        }
+
+        // GET: ShopSouvenir/BrandManager/Edit/5
+        public async Task<IActionResult> Edit(int? id)
+        {
+            if (id == null)
+            {
+                return NotFound();
+            }
+            var brand = await _context.BrandSous.FindAsync(id);
+            if (brand == null)
+            {
+                return NotFound();
+            }
+            return View(brand);
+        }
+
+        // POST: ShopSouvenir/BrandManager/Edit/5
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> Edit(int id, [Bind("Id,Name,Description")] BrandSouModel brand)
+        {
+            if (id != brand.Id)
+            {
+                return NotFound();
+            }
+            if (ModelState.IsValid)
+            {
+                try
+                {
+                    _context.Update(brand);
+                    await _context.SaveChangesAsync();
+                    TempData["SuccessMessage"] = "Cập nhật thành công!";
+                }
+                catch (DbUpdateConcurrencyException)
+                {
+                    if (!BrandExists(brand.Id))
+                    {
+                        return NotFound();
+                    }
+                    else
+                    {
+                        throw;
+                    }
+                }
+                return RedirectToAction(nameof(Index));
+            }
+            return View(brand);
+        }
+
+        // GET: ShopSouvenir/BrandManager/Delete/5
+        public async Task<IActionResult> Delete(int? id)
+        {
+            if (id == null)
+            {
+                return NotFound();
+            }
+            var brand = await _context.BrandSous.FirstOrDefaultAsync(b => b.Id == id);
+            if (brand == null)
+            {
+                return NotFound();
+            }
+            return View(brand);
+        }
+
+        // POST: ShopSouvenir/BrandManager/Delete/5
+        [HttpPost, ActionName("Delete")]
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> DeleteConfirmed(int id)
+        {
+            var brand = await _context.BrandSous.FindAsync(id);
+            if (brand != null)
+            {
+                _context.BrandSous.Remove(brand);
+                await _context.SaveChangesAsync();
+                TempData["SuccessMessage"] = "Đã xóa thành công!";
+            }
+            return RedirectToAction(nameof(Index));
+        }
+
+        private bool BrandExists(int id)
+        {
+            return _context.BrandSous.Any(e => e.Id == id);
+        }
+    }
+}

--- a/Netflixx/Areas/ShopSouvenir/Views/BrandManager/Create.cshtml
+++ b/Netflixx/Areas/ShopSouvenir/Views/BrandManager/Create.cshtml
@@ -1,0 +1,27 @@
+@model Netflixx.Models.BrandSouModel
+@{
+    ViewData["Title"] = "Thêm Thương Hiệu";
+}
+@await Html.PartialAsync("_BrandManagerMenu")
+<div class="main-content" id="mainContent">
+    <div class="container">
+        <h3 class="text-white mb-4">@ViewData["Title"]</h3>
+        <form asp-action="Create" method="post" id="brandForm">
+            <div class="mb-3">
+                <label asp-for="Name" class="form-label"></label>
+                <input asp-for="Name" class="form-control" required />
+                <span asp-validation-for="Name" class="text-danger"></span>
+            </div>
+            <div class="mb-3">
+                <label asp-for="Description" class="form-label"></label>
+                <textarea asp-for="Description" class="form-control" required></textarea>
+                <span asp-validation-for="Description" class="text-danger"></span>
+            </div>
+            <button type="submit" class="btn btn-primary">Lưu</button>
+        </form>
+    </div>
+</div>
+@await Html.PartialAsync("_BrandManagerMenuScripts")
+@section Scripts {
+    @{ await Html.RenderPartialAsync("_ValidationScriptsPartial"); }
+}

--- a/Netflixx/Areas/ShopSouvenir/Views/BrandManager/Delete.cshtml
+++ b/Netflixx/Areas/ShopSouvenir/Views/BrandManager/Delete.cshtml
@@ -1,0 +1,17 @@
+@model Netflixx.Models.BrandSouModel
+@{
+    ViewData["Title"] = "Xóa Thương Hiệu";
+}
+@await Html.PartialAsync("_BrandManagerMenu")
+<div class="main-content" id="mainContent">
+    <div class="container">
+        <h3 class="text-white mb-4">@ViewData["Title"]</h3>
+        <h5 class="text-white">Bạn có chắc muốn xóa "@Model.Name"?</h5>
+        <form asp-action="Delete">
+            <input type="hidden" asp-for="Id" />
+            <button type="submit" class="btn btn-danger">Xóa</button>
+            <a asp-action="Index" class="btn btn-secondary">Hủy</a>
+        </form>
+    </div>
+</div>
+@await Html.PartialAsync("_BrandManagerMenuScripts")

--- a/Netflixx/Areas/ShopSouvenir/Views/BrandManager/Details.cshtml
+++ b/Netflixx/Areas/ShopSouvenir/Views/BrandManager/Details.cshtml
@@ -1,0 +1,21 @@
+@model Netflixx.Models.BrandSouModel
+@{
+    ViewData["Title"] = "Chi Tiết Thương Hiệu";
+}
+@await Html.PartialAsync("_BrandManagerMenu")
+<div class="main-content" id="mainContent">
+    <div class="container">
+        <h3 class="text-white mb-4">@ViewData["Title"]</h3>
+        <dl class="row text-white">
+            <dt class="col-sm-2">ID</dt>
+            <dd class="col-sm-10">@Model.Id</dd>
+            <dt class="col-sm-2">Tên</dt>
+            <dd class="col-sm-10">@Model.Name</dd>
+            <dt class="col-sm-2">Mô tả</dt>
+            <dd class="col-sm-10">@Model.Description</dd>
+        </dl>
+        <a asp-action="Edit" asp-route-id="@Model.Id" class="btn btn-warning">Edit</a>
+        <a asp-action="Index" class="btn btn-secondary">Back to list</a>
+    </div>
+</div>
+@await Html.PartialAsync("_BrandManagerMenuScripts")

--- a/Netflixx/Areas/ShopSouvenir/Views/BrandManager/Edit.cshtml
+++ b/Netflixx/Areas/ShopSouvenir/Views/BrandManager/Edit.cshtml
@@ -1,0 +1,28 @@
+@model Netflixx.Models.BrandSouModel
+@{
+    ViewData["Title"] = "Chỉnh Sửa Thương Hiệu";
+}
+@await Html.PartialAsync("_BrandManagerMenu")
+<div class="main-content" id="mainContent">
+    <div class="container">
+        <h3 class="text-white mb-4">@ViewData["Title"]</h3>
+        <form asp-action="Edit" method="post">
+            <input type="hidden" asp-for="Id" />
+            <div class="mb-3">
+                <label asp-for="Name" class="form-label"></label>
+                <input asp-for="Name" class="form-control" required />
+                <span asp-validation-for="Name" class="text-danger"></span>
+            </div>
+            <div class="mb-3">
+                <label asp-for="Description" class="form-label"></label>
+                <textarea asp-for="Description" class="form-control" required></textarea>
+                <span asp-validation-for="Description" class="text-danger"></span>
+            </div>
+            <button type="submit" class="btn btn-primary">Lưu</button>
+        </form>
+    </div>
+</div>
+@await Html.PartialAsync("_BrandManagerMenuScripts")
+@section Scripts {
+    @{ await Html.RenderPartialAsync("_ValidationScriptsPartial"); }
+}

--- a/Netflixx/Areas/ShopSouvenir/Views/BrandManager/Index.cshtml
+++ b/Netflixx/Areas/ShopSouvenir/Views/BrandManager/Index.cshtml
@@ -1,0 +1,63 @@
+@model IEnumerable<Netflixx.Models.BrandSouModel>
+@{
+    ViewData["Title"] = "Quản Lý Thương Hiệu";
+}
+@section Styles {
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css" />
+    <link rel="stylesheet" href="https://cdn.datatables.net/1.10.21/css/dataTables.bootstrap4.min.css" />
+}
+@await Html.PartialAsync("_BrandManagerMenu")
+<div class="main-content" id="mainContent">
+    <div class="container-fluid">
+        <div class="d-flex justify-content-between align-items-center mb-4">
+            <h3 class="text-white">@ViewData["Title"]</h3>
+            <a asp-action="Create" class="btn btn-success">
+                <i class="fas fa-plus"></i> Thêm thương hiệu
+            </a>
+        </div>
+        <table class="table table-striped table-bordered" id="brandTable">
+            <thead class="thead-dark">
+                <tr>
+                    <th>Mã</th>
+                    <th>Tên thương hiệu</th>
+                    <th>Mô tả</th>
+                    <th>Hành động</th>
+                </tr>
+            </thead>
+            <tbody>
+            @foreach (var brand in Model)
+            {
+                <tr>
+                    <td>@brand.Id</td>
+                    <td>@brand.Name</td>
+                    <td>@brand.Description</td>
+                    <td>
+                        <div class="btn-group" role="group">
+                            <a asp-action="Edit" asp-route-id="@brand.Id" class="btn btn-warning btn-sm"><i class="fas fa-edit"></i></a>
+                            <a asp-action="Details" asp-route-id="@brand.Id" class="btn btn-info btn-sm"><i class="fas fa-eye"></i></a>
+                            <a asp-action="Delete" asp-route-id="@brand.Id" class="btn btn-danger btn-sm"><i class="fas fa-trash"></i></a>
+                        </div>
+                    </td>
+                </tr>
+            }
+            </tbody>
+        </table>
+    </div>
+</div>
+@await Html.PartialAsync("_BrandManagerMenuScripts")
+@section Scripts {
+    <script src="https://code.jquery.com/jquery-3.5.1.min.js"></script>
+    <script src="https://cdn.datatables.net/1.10.21/js/jquery.dataTables.min.js"></script>
+    <script src="https://cdn.datatables.net/1.10.21/js/dataTables.bootstrap4.min.js"></script>
+    <script>
+        $(function () {
+            $('#brandTable').DataTable({
+                responsive: true,
+                language: {
+                    url: '//cdn.datatables.net/plug-ins/1.13.6/i18n/vi.json'
+                },
+                pageLength: 10
+            });
+        });
+    </script>
+}

--- a/Netflixx/Areas/ShopSouvenir/Views/BrandManager/_BrandManagerMenu.cshtml
+++ b/Netflixx/Areas/ShopSouvenir/Views/BrandManager/_BrandManagerMenu.cshtml
@@ -1,0 +1,66 @@
+<style>
+    body {
+        background-color: #1f1f1f;
+        color: #fff;
+        transition: margin-left 0.3s;
+        overflow-x: hidden;
+    }
+    .navbar { z-index: 1100; }
+    .sidebar {
+        position: fixed;
+        top: 70px;
+        left: 0;
+        height: calc(100vh - 70px);
+        width: 230px;
+        background-color: #2c2c2c;
+        overflow-y: auto;
+        transition: transform 0.3s ease;
+        z-index: 1000;
+        display: flex;
+        flex-direction: column;
+        border-right: 1px solid #444;
+    }
+    .sidebar.collapsed { transform: translateX(-100%); }
+    .sidebar a {
+        display: block;
+        padding: 15px 20px;
+        color: #fff;
+        text-decoration: none;
+        white-space: nowrap;
+    }
+    .sidebar a:hover { background-color: #ff4d6d; }
+    .main-content {
+        margin-left: 230px;
+        padding: 100px 20px 20px;
+        transition: margin-left 0.3s ease;
+    }
+    .main-content.expanded { margin-left: 0; }
+    .toggle-btn, .show-sidebar-btn {
+        position: fixed;
+        top: 75px;
+        z-index: 1200;
+        background-color: #ff4d6d;
+        color: #fff;
+        border: none;
+        padding: 5px 10px;
+        border-radius: 5px;
+    }
+    .toggle-btn { left: 10px; }
+    .show-sidebar-btn { left: 10px; display: none; }
+    .sidebar.collapsed ~ .show-sidebar-btn { display: block; }
+</style>
+<div class="sidebar" id="sidebar">
+    <div>
+        <h5 class="px-3 py-2 mb-0 text-uppercase fw-semibold text-white text-center">Menu</h5>
+        <a asp-controller="BrandManager" asp-action="Index" asp-area="ShopSouvenir"><i class="fas fa-list"></i> Danh sách thương hiệu</a>
+        <a asp-controller="BrandManager" asp-action="Create" asp-area="ShopSouvenir"><i class="fas fa-plus"></i> Thêm thương hiệu</a>
+    </div>
+</div>
+<div>
+    <button id="toggleSidebar" class="toggle-btn">
+        <i class="fas fa-angle-double-left"></i>
+    </button>
+    <button id="showSidebar" class="show-sidebar-btn">
+        <i class="fas fa-angle-double-right"></i>
+    </button>
+</div>

--- a/Netflixx/Areas/ShopSouvenir/Views/BrandManager/_BrandManagerMenuScripts.cshtml
+++ b/Netflixx/Areas/ShopSouvenir/Views/BrandManager/_BrandManagerMenuScripts.cshtml
@@ -1,0 +1,20 @@
+<script>
+    document.addEventListener('DOMContentLoaded', function () {
+        var toggle = document.getElementById('toggleSidebar');
+        var show = document.getElementById('showSidebar');
+        if (toggle) {
+            toggle.addEventListener('click', function () {
+                document.getElementById('sidebar').classList.add('collapsed');
+                document.getElementById('mainContent').classList.add('expanded');
+                if (show) show.style.display = 'block';
+            });
+        }
+        if (show) {
+            show.addEventListener('click', function () {
+                document.getElementById('sidebar').classList.remove('collapsed');
+                document.getElementById('mainContent').classList.remove('expanded');
+                show.style.display = 'none';
+            });
+        }
+    });
+</script>

--- a/Netflixx/Areas/ShopSouvenir/Views/_ViewImports.cshtml
+++ b/Netflixx/Areas/ShopSouvenir/Views/_ViewImports.cshtml
@@ -1,0 +1,2 @@
+@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
+@using Netflixx.Models

--- a/Netflixx/Views/Shared/_Layout.cshtml
+++ b/Netflixx/Views/Shared/_Layout.cshtml
@@ -50,6 +50,7 @@
                     <li class="nav-item"><a class="nav-link" asp-controller="Blog" asp-action="Index">Blog</a></li>
                     <li class="nav-item"><a class="nav-link" asp-area="ShopSouvenir" asp-controller="Home" asp-action="Index">Souvenir</a></li>
                     <li class="nav-item"><a class="nav-link" asp-area="ProductionManager" asp-controller="ProductionManager" asp-action="Index">List Company</a></li>
+                    <li class="nav-item"><a class="nav-link" asp-area="ShopSouvenir" asp-controller="BrandManager" asp-action="Index">Brand Manager</a></li>
                     <li class="nav-item"><a class="nav-link" asp-controller="Contact" asp-action="Index">Contact</a></li>
                     <li class="nav-item"><a class="nav-link" href="#">Series</a></li>
                     <li class="nav-item"><a class="nav-link" href="#">Categories</a></li>


### PR DESCRIPTION
## Summary
- implement `BrandManagerController` for Souvenir brands
- create BrandManager CRUD views with sidebar menu
- add `_ViewImports` for ShopSouvenir area
- link Brand Manager from the main layout

## Testing
- `dotnet build Netflixx.sln` *(fails: RZ1031 errors in existing ProductSou views)*

------
https://chatgpt.com/codex/tasks/task_e_68778e13855483268970fd0295a4c366