### PR TITLE
Implement BrandManager trash and history

### DIFF
--- a/Netflixx/Areas/ShopSouvenir/Views/BrandManager/HardDelete.cshtml
+++ b/Netflixx/Areas/ShopSouvenir/Views/BrandManager/HardDelete.cshtml
@@ -1,0 +1,17 @@
+@model Netflixx.Models.BrandSouModel
+@{
+    ViewData["Title"] = "Xóa vĩnh viễn";
+}
+@await Html.PartialAsync("_BrandManagerMenu")
+<div class="main-content" id="mainContent">
+    <div class="container">
+        <h3 class="text-white mb-4">@ViewData["Title"]</h3>
+        <p class="text-white">Bạn có chắc muốn xóa vĩnh viễn "@Model.Name"?</p>
+        <form asp-action="HardDelete" method="post">
+            <input type="hidden" asp-for="Id" />
+            <button type="submit" class="btn btn-danger">Xóa</button>
+            <a asp-action="Trash" class="btn btn-secondary">Hủy</a>
+        </form>
+    </div>
+</div>
+@await Html.PartialAsync("_BrandManagerMenuScripts")

--- a/Netflixx/Areas/ShopSouvenir/Views/BrandManager/History.cshtml
+++ b/Netflixx/Areas/ShopSouvenir/Views/BrandManager/History.cshtml
@@ -1,0 +1,31 @@
+@model IEnumerable<Netflixx.Models.BrandHistory>
+@{
+    ViewData["Title"] = "Lịch sử";
+}
+@await Html.PartialAsync("_BrandManagerMenu")
+<div class="main-content" id="mainContent">
+    <div class="container">
+        <h3 class="text-white mb-4">@ViewData["Title"]</h3>
+        <table class="table table-striped table-bordered">
+            <thead class="thead-dark">
+                <tr>
+                    <th>Thao tác</th>
+                    <th>Chi tiết</th>
+                    <th>Thời gian</th>
+                </tr>
+            </thead>
+            <tbody>
+            @foreach (var item in Model)
+            {
+                <tr>
+                    <td>@item.Action</td>
+                    <td><a asp-action="HistoryDetails" asp-route-id="@item.Id" asp-route-returnTo="History" asp-route-brandId="@ViewBag.BrandId">Xem</a></td>
+                    <td>@item.Timestamp.ToString("dd/MM/yyyy HH:mm")</td>
+                </tr>
+            }
+            </tbody>
+        </table>
+        <a asp-action="Index" class="btn btn-secondary">Quay lại</a>
+    </div>
+</div>
+@await Html.PartialAsync("_BrandManagerMenuScripts")

--- a/Netflixx/Areas/ShopSouvenir/Views/BrandManager/HistoryAll.cshtml
+++ b/Netflixx/Areas/ShopSouvenir/Views/BrandManager/HistoryAll.cshtml
@@ -1,0 +1,34 @@
+@model IEnumerable<Netflixx.Models.BrandHistory>
+@{
+    ViewData["Title"] = "Tất cả lịch sử";
+}
+@await Html.PartialAsync("_BrandManagerMenu")
+<div class="main-content" id="mainContent">
+    <div class="container">
+        <h3 class="text-white mb-4">@ViewData["Title"]</h3>
+        <table class="table table-striped table-bordered">
+            <thead class="thead-dark">
+                <tr>
+                    <th>Thương hiệu</th>
+                    <th>Thao tác</th>
+                    <th>Thời gian</th>
+                    <th></th>
+                </tr>
+            </thead>
+            <tbody>
+            @foreach (var item in Model)
+            {
+                <tr>
+                    <td>@item.BrandName</td>
+                    <td>@item.Action</td>
+                    <td>@item.Timestamp.ToString("dd/MM/yyyy HH:mm")</td>
+                    <td>
+                        <a asp-action="HistoryDetails" asp-route-id="@item.Id" asp-route-returnTo="HistoryAll" class="btn btn-info btn-sm">Chi tiết</a>
+                    </td>
+                </tr>
+            }
+            </tbody>
+        </table>
+    </div>
+</div>
+@await Html.PartialAsync("_BrandManagerMenuScripts")

--- a/Netflixx/Areas/ShopSouvenir/Views/BrandManager/HistoryDetails.cshtml
+++ b/Netflixx/Areas/ShopSouvenir/Views/BrandManager/HistoryDetails.cshtml
@@ -1,0 +1,29 @@
+@model Netflixx.Models.BrandHistory
+@{
+    ViewData["Title"] = "Chi tiết lịch sử";
+}
+@await Html.PartialAsync("_BrandManagerMenu")
+<div class="main-content" id="mainContent">
+    <div class="container">
+        <h3 class="text-white mb-4">@ViewData["Title"]</h3>
+        <dl class="row text-white">
+            <dt class="col-sm-3">Thương hiệu</dt>
+            <dd class="col-sm-9">@Model.BrandName</dd>
+            <dt class="col-sm-3">Thao tác</dt>
+            <dd class="col-sm-9">@Model.Action</dd>
+            <dt class="col-sm-3">Chi tiết</dt>
+            <dd class="col-sm-9">@Model.Details</dd>
+            <dt class="col-sm-3">Thời gian</dt>
+            <dd class="col-sm-9">@Model.Timestamp.ToString("dd/MM/yyyy HH:mm")</dd>
+        </dl>
+        @if (ViewBag.ReturnTo == "History")
+        {
+            <a asp-action="History" asp-route-id="@Model.BrandId" class="btn btn-secondary">Quay lại</a>
+        }
+        else
+        {
+            <a asp-action="HistoryAll" class="btn btn-secondary">Quay lại</a>
+        }
+    </div>
+</div>
+@await Html.PartialAsync("_BrandManagerMenuScripts")

--- a/Netflixx/Areas/ShopSouvenir/Views/BrandManager/Trash.cshtml
+++ b/Netflixx/Areas/ShopSouvenir/Views/BrandManager/Trash.cshtml
@@ -1,0 +1,44 @@
+@model IEnumerable<Netflixx.Models.BrandSouModel>
+@{
+    ViewData["Title"] = "Thùng rác";
+}
+@await Html.PartialAsync("_BrandManagerMenu")
+<div class="main-content" id="mainContent">
+    <div class="container">
+        <h3 class="text-white mb-4">@ViewData["Title"]</h3>
+        @if (Model.Any())
+        {
+            <table class="table table-striped table-bordered">
+                <thead class="thead-dark">
+                    <tr>
+                        <th>Tên</th>
+                        <th>Mô tả</th>
+                        <th>Ngày xóa</th>
+                        <th>Hành động</th>
+                    </tr>
+                </thead>
+                <tbody>
+                @foreach (var item in Model)
+                {
+                    <tr>
+                        <td>@item.Name</td>
+                        <td>@item.Description</td>
+                        <td>@item.DeletedAt?.ToString("dd/MM/yyyy")</td>
+                        <td>
+                            <form asp-action="Restore" asp-route-id="@item.Id" method="post" class="d-inline">
+                                <button type="submit" class="btn btn-success btn-sm">Khôi phục</button>
+                            </form>
+                            <a asp-action="HardDelete" asp-route-id="@item.Id" class="btn btn-danger btn-sm">Xóa vĩnh viễn</a>
+                        </td>
+                    </tr>
+                }
+                </tbody>
+            </table>
+        }
+        else
+        {
+            <p class="text-white">Không có thương hiệu nào trong thùng rác.</p>
+        }
+    </div>
+</div>
+@await Html.PartialAsync("_BrandManagerMenuScripts")

--- a/Netflixx/Areas/ShopSouvenir/Views/BrandManager/_BrandManagerMenu.cshtml
+++ b/Netflixx/Areas/ShopSouvenir/Views/BrandManager/_BrandManagerMenu.cshtml
@@ -54,6 +54,8 @@
         <h5 class="px-3 py-2 mb-0 text-uppercase fw-semibold text-white text-center">Menu</h5>
         <a asp-controller="BrandManager" asp-action="Index" asp-area="ShopSouvenir"><i class="fas fa-list"></i> Danh sách thương hiệu</a>
         <a asp-controller="BrandManager" asp-action="Create" asp-area="ShopSouvenir"><i class="fas fa-plus"></i> Thêm thương hiệu</a>
+        <a asp-controller="BrandManager" asp-action="HistoryAll" asp-area="ShopSouvenir"><i class="fas fa-history"></i> Lịch sử</a>
+        <a asp-controller="BrandManager" asp-action="Trash" asp-area="ShopSouvenir"><i class="fas fa-trash-alt"></i> Thùng rác</a>
     </div>
 </div>
 <div>

--- a/Netflixx/Models/BrandHistory.cs
+++ b/Netflixx/Models/BrandHistory.cs
@@ -1,0 +1,27 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace Netflixx.Models
+{
+    public class BrandHistory
+    {
+        [Key]
+        public int Id { get; set; }
+
+        public int? BrandId { get; set; }
+
+        [StringLength(100)]
+        public string? BrandName { get; set; }
+
+        [StringLength(20)]
+        public string Action { get; set; } = string.Empty;
+
+        public string? Details { get; set; }
+
+        public DateTime Timestamp { get; set; }
+
+        [ForeignKey("BrandId")]
+        public BrandSouModel? Brand { get; set; }
+    }
+}

--- a/Netflixx/Models/BrandSouModel.cs
+++ b/Netflixx/Models/BrandSouModel.cs
@@ -14,7 +14,17 @@ namespace Netflixx.Models
 
         [Required(ErrorMessage = "Description is required")]
         public string Description { get; set; } = string.Empty;
+        public DateTime CreatedAt { get; set; }
+
+        public DateTime UpdatedAt { get; set; }
+
+        public bool IsDeleted { get; set; } = false;
+
+        public DateTime? DeletedAt { get; set; }
+
         public virtual ICollection<ProductSouModel> Products { get; set; } = new HashSet<ProductSouModel>();
+
+        public virtual ICollection<BrandHistory> Histories { get; set; } = new List<BrandHistory>();
 
     }
 }

--- a/Netflixx/Repositories/DBContext.cs
+++ b/Netflixx/Repositories/DBContext.cs
@@ -43,6 +43,7 @@ namespace Netflixx.Repositories
         public virtual DbSet<DailyRevenueModel> DailyRevenue { get; set; }
         public virtual DbSet<ProductionManager> ProductionManagers { get; set; }
         public virtual DbSet<ProductionManagerHistory> ProductionManagerHistories { get; set; }
+        public virtual DbSet<BrandHistory> BrandHistories { get; set; }
 
         public virtual DbSet<LoginHistory> LoginHistory { get; set; }
         public virtual DbSet<FavoriteFilmsModel> FavoriteFilms { get; set; }
@@ -69,10 +70,27 @@ namespace Netflixx.Repositories
                   .Property(h => h.Details)
                   .HasColumnType("nvarchar(max)");
             modelBuilder.Entity<FilmsModel>()
-       .HasOne(f => f.ProductionManager)           
-       .WithMany(p => p.Films)                     
-       .HasForeignKey(f => f.ProductionManagerId)  
-       .OnDelete(DeleteBehavior.SetNull);         
+       .HasOne(f => f.ProductionManager)
+       .WithMany(p => p.Films)
+       .HasForeignKey(f => f.ProductionManagerId)
+       .OnDelete(DeleteBehavior.SetNull);
+
+            modelBuilder.Entity<BrandSouModel>()
+                .Property(b => b.IsDeleted)
+                .HasDefaultValue(false);
+            modelBuilder.Entity<BrandSouModel>()
+                .Property(b => b.DeletedAt);
+
+            modelBuilder.Entity<BrandHistory>()
+                .ToTable("BrandHistories");
+            modelBuilder.Entity<BrandHistory>()
+                .HasOne(h => h.Brand)
+                .WithMany(b => b.Histories)
+                .HasForeignKey(h => h.BrandId)
+                .OnDelete(DeleteBehavior.SetNull);
+            modelBuilder.Entity<BrandHistory>()
+                .Property(h => h.Details)
+                .HasColumnType("nvarchar(max)");
 
             base.OnModelCreating(modelBuilder);
 


### PR DESCRIPTION
## Summary
- add `BrandHistory` entity for tracking changes
- extend `BrandSouModel` with timestamps and deletion fields
- wire up brand history and deletion settings in `DBContext`
- enhance `BrandManagerController` with history/trash/hard delete actions
- add history and trash pages with a simple UI
- update BrandManager menu with links to new pages

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877a0df51308326ae607f820abeac60