### PR TITLE
Update BrandManager UI to match ProductionManager

### DIFF
--- a/Netflixx/Areas/ShopSouvenir/Views/BrandManager/Create.cshtml
+++ b/Netflixx/Areas/ShopSouvenir/Views/BrandManager/Create.cshtml
@@ -2,23 +2,97 @@
 @{
     ViewData["Title"] = "Thêm Thương Hiệu";
 }
+@section Styles {
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css" />
+}
+<style>
+    body {
+        background-color: #1f1f1f;
+        color: #fff;
+        transition: margin-left 0.3s;
+        overflow-x: hidden;
+    }
+    .navbar { z-index: 1100; }
+    .sidebar {
+        position: fixed;
+        top: 70px;
+        left: 0;
+        height: calc(100vh - 70px);
+        width: 230px;
+        background-color: #2c2c2c;
+        overflow-y: auto;
+        transition: transform 0.3s ease;
+        z-index: 1000;
+        display: flex;
+        flex-direction: column;
+        border-right: 1px solid #444;
+    }
+    .sidebar.collapsed { transform: translateX(-100%); }
+    .sidebar a {
+        display: block;
+        padding: 15px 20px;
+        color: #fff;
+        text-decoration: none;
+        white-space: nowrap;
+    }
+    .sidebar a:hover { background-color: #ff4d6d; }
+    .main-content { margin-left: 230px; padding: 100px 20px 20px; transition: margin-left 0.3s ease; }
+    .main-content.expanded { margin-left: 0; }
+    .toggle-btn, .show-sidebar-btn {
+        position: fixed; top: 75px; z-index: 1200; background-color: #ff4d6d; color: #fff; border: none; padding: 5px 10px; border-radius: 5px;
+    }
+    .toggle-btn { left: 10px; }
+    .show-sidebar-btn { left: 10px; display: none; }
+    .sidebar.collapsed ~ .show-sidebar-btn { display: block; }
+    .card { background: linear-gradient(135deg, #2c2c2c 0%, #383838 100%); border-radius: 20px; border: 1px solid #444; margin-bottom: 20px; box-shadow: 0 10px 30px rgba(0,0,0,0.3); overflow: hidden; }
+    .card-header { background: rgba(255, 77, 109, 0.1); color: #fff; border-bottom: 1px solid #444; padding: 1.5rem; }
+    .form-control { background-color: #3c3c3c; border: 1px solid #555; color: #fff; }
+    .form-control:focus { background-color: #3c3c3c; border-color: #ff4d6d; color: #fff; box-shadow: 0 0 0 0.2rem rgba(255,77,109,0.25); }
+    .form-label { font-weight: 600; margin-bottom: 8px; color: #fff; }
+    .required::after { content: " *"; color: #ff4d6d; }
+    .btn-primary { background-color: #ff4d6d; border-color: #ff4d6d; padding: 10px 20px; font-weight: 500; }
+    .btn-primary:hover { background-color: #e63946; border-color: #e63946; }
+    .btn-secondary { background-color: #6c757d; border-color: #6c757d; padding: 10px 20px; font-weight: 500; }
+    .btn-secondary:hover { background-color: #5a6268; border-color: #545b62; }
+    .alert-danger { background-color: #2c1618; border-color: #5c2125; color: #f8d7da; }
+    .text-danger { color: #ff6b6b !important; }
+    .form-section { background-color: #2a2a2a; border-radius: 8px; padding: 20px; margin-bottom: 20px; border: 1px solid #404040; }
+    .form-section-title { color: #ff4d6d; font-weight: 600; margin-bottom: 15px; padding-bottom: 8px; border-bottom: 2px solid #ff4d6d; }
+    .page-header { display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 1rem; }
+    .page-title { color: #fff; font-weight: 600; font-size: 1.75rem; }
+</style>
 @await Html.PartialAsync("_BrandManagerMenu")
 <div class="main-content" id="mainContent">
-    <div class="container">
-        <h3 class="text-white mb-4">@ViewData["Title"]</h3>
-        <form asp-action="Create" method="post" id="brandForm">
-            <div class="mb-3">
-                <label asp-for="Name" class="form-label"></label>
-                <input asp-for="Name" class="form-control" required />
-                <span asp-validation-for="Name" class="text-danger"></span>
+    <div class="container-fluid px-4 py-3">
+        <div class="row mb-4">
+            <div class="col-12">
+                <div class="page-header">
+                    <h2 class="page-title mb-0">
+                        <i class="fas fa-plus me-2 text-success"></i>
+                        Thêm Thương Hiệu
+                    </h2>
+                </div>
             </div>
-            <div class="mb-3">
-                <label asp-for="Description" class="form-label"></label>
-                <textarea asp-for="Description" class="form-control" required></textarea>
-                <span asp-validation-for="Description" class="text-danger"></span>
+        </div>
+        <div class="row">
+            <div class="col-md-8 offset-md-2">
+                <div class="card shadow">
+                    <div class="card-body">
+                        <form asp-action="Create" method="post" novalidate>
+                            @await Html.PartialAsync("_BrandManagerForm")
+                            <div class="form-group text-center">
+                                <a asp-action="Index" class="btn btn-secondary me-3">
+                                    <i class="fas fa-arrow-left me-2"></i>Quay lại
+                                </a>
+                                <button type="submit" class="btn btn-primary">
+                                    <i class="fas fa-save me-2"></i>Lưu thông tin
+                                </button>
+                            </div>
+                        </form>
+                    </div>
+                </div>
             </div>
-            <button type="submit" class="btn btn-primary">Lưu</button>
-        </form>
+        </div>
     </div>
 </div>
 @await Html.PartialAsync("_BrandManagerMenuScripts")

--- a/Netflixx/Areas/ShopSouvenir/Views/BrandManager/Delete.cshtml
+++ b/Netflixx/Areas/ShopSouvenir/Views/BrandManager/Delete.cshtml
@@ -1,17 +1,66 @@
 @model Netflixx.Models.BrandSouModel
 @{
+    bool isAjax = Context.Request.Headers["X-Requested-With"] == "XMLHttpRequest";
+    if (isAjax)
+    {
+        Layout = null;
+    }
     ViewData["Title"] = "Xóa Thương Hiệu";
 }
-@await Html.PartialAsync("_BrandManagerMenu")
-<div class="main-content" id="mainContent">
-    <div class="container">
-        <h3 class="text-white mb-4">@ViewData["Title"]</h3>
-        <h5 class="text-white">Bạn có chắc muốn xóa "@Model.Name"?</h5>
-        <form asp-action="Delete">
+@if (!isAjax)
+{
+@section Styles {
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css" />
+    <style>
+        body { background-color:#1f1f1f; color:#fff; transition:margin-left 0.3s; overflow-x:hidden; }
+        .navbar{ z-index:1100; }
+        .sidebar{ position:fixed; top:70px; left:0; height:calc(100vh - 70px); width:230px; background-color:#2c2c2c; overflow-y:auto; transition:transform 0.3s ease; z-index:1000; display:flex; flex-direction:column; border-right:1px solid #444; }
+        .sidebar.collapsed{ transform:translateX(-100%); }
+        .sidebar a{ display:block; padding:15px 20px; color:#fff; text-decoration:none; white-space:nowrap; }
+        .sidebar a:hover{ background-color:#ff4d6d; }
+        .main-content{ margin-left:230px; padding:100px 20px 20px; transition:margin-left 0.3s ease; }
+        .main-content.expanded{ margin-left:0; }
+        .toggle-btn,.show-sidebar-btn{ position:fixed; top:75px; z-index:1200; background-color:#ff4d6d; color:#fff; border:none; padding:5px 10px; border-radius:5px; }
+        .toggle-btn{ left:10px; }
+        .show-sidebar-btn{ left:10px; display:none; }
+        .sidebar.collapsed ~ .show-sidebar-btn{ display:block; }
+    </style>
+}
+}
+@if (!isAjax)
+{
+    @await Html.PartialAsync("_BrandManagerMenu")
+    <div class="main-content" id="mainContent">
+}
+<div class="modal-content">
+    <form asp-action="Delete" method="post">
+        <div class="modal-header">
+            <h5 class="modal-title">@ViewData["Title"]</h5>
+            <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close"></button>
+        </div>
+        <div class="modal-body">
+            <div class="modal-warning">
+                <i class="fas fa-exclamation-triangle"></i>
+                <p>Bạn chắc chắn muốn xóa thương hiệu này?</p>
+            </div>
+            <div class="company-modal-info">
+                <h3 class="company-modal-name">@Model.Name</h3>
+                <p>@Model.Description</p>
+            </div>
+        </div>
+        <div class="modal-footer">
             <input type="hidden" asp-for="Id" />
-            <button type="submit" class="btn btn-danger">Xóa</button>
-            <a asp-action="Index" class="btn btn-secondary">Hủy</a>
-        </form>
-    </div>
+            <button type="submit" class="btn btn-danger">
+                <i class="fas fa-trash-alt"></i> Xác nhận xóa
+            </button>
+            <button type="button" class="btn btn-outline-light" data-bs-dismiss="modal">
+                <i class="fas fa-times"></i> Hủy bỏ
+            </button>
+        </div>
+    </form>
 </div>
-@await Html.PartialAsync("_BrandManagerMenuScripts")
+@if (!isAjax)
+{
+    </div>
+    @await Html.PartialAsync("_BrandManagerMenuScripts")
+}

--- a/Netflixx/Areas/ShopSouvenir/Views/BrandManager/Details.cshtml
+++ b/Netflixx/Areas/ShopSouvenir/Views/BrandManager/Details.cshtml
@@ -2,20 +2,48 @@
 @{
     ViewData["Title"] = "Chi Tiết Thương Hiệu";
 }
+@section Styles {
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css" />
+}
 @await Html.PartialAsync("_BrandManagerMenu")
 <div class="main-content" id="mainContent">
-    <div class="container">
-        <h3 class="text-white mb-4">@ViewData["Title"]</h3>
-        <dl class="row text-white">
-            <dt class="col-sm-2">ID</dt>
-            <dd class="col-sm-10">@Model.Id</dd>
-            <dt class="col-sm-2">Tên</dt>
-            <dd class="col-sm-10">@Model.Name</dd>
-            <dt class="col-sm-2">Mô tả</dt>
-            <dd class="col-sm-10">@Model.Description</dd>
-        </dl>
-        <a asp-action="Edit" asp-route-id="@Model.Id" class="btn btn-warning">Edit</a>
-        <a asp-action="Index" class="btn btn-secondary">Back to list</a>
+    <div class="container-fluid px-4 py-3">
+        <div class="row mb-4">
+            <div class="col-12">
+                <div class="d-flex justify-content-between align-items-center">
+                    <div class="page-header">
+                        <h2 class="page-title mb-0">
+                            <i class="fas fa-tags me-2 text-primary"></i>
+                            Chi Tiết Thương Hiệu
+                        </h2>
+                    </div>
+                    <div class="action-buttons">
+                        <a asp-action="Index" class="btn btn-outline-secondary me-2">
+                            <i class="fas fa-arrow-left me-1"></i>Quay lại
+                        </a>
+                        <a asp-action="Edit" asp-route-id="@Model.Id" class="btn btn-primary">
+                            <i class="fas fa-edit me-1"></i>Chỉnh sửa
+                        </a>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="row g-4">
+            <div class="col-md-8 offset-md-2">
+                <div class="card shadow">
+                    <div class="card-body">
+                        <dl class="row mb-0">
+                            <dt class="col-sm-3">ID</dt>
+                            <dd class="col-sm-9">@Model.Id</dd>
+                            <dt class="col-sm-3">Tên</dt>
+                            <dd class="col-sm-9">@Model.Name</dd>
+                            <dt class="col-sm-3">Mô tả</dt>
+                            <dd class="col-sm-9">@Model.Description</dd>
+                        </dl>
+                    </div>
+                </div>
+            </div>
+        </div>
     </div>
 </div>
 @await Html.PartialAsync("_BrandManagerMenuScripts")

--- a/Netflixx/Areas/ShopSouvenir/Views/BrandManager/Edit.cshtml
+++ b/Netflixx/Areas/ShopSouvenir/Views/BrandManager/Edit.cshtml
@@ -2,24 +2,72 @@
 @{
     ViewData["Title"] = "Chỉnh Sửa Thương Hiệu";
 }
+@section Styles {
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css" />
+}
+<style>
+    body { background-color: #1f1f1f; color: #fff; transition: margin-left 0.3s; overflow-x: hidden; }
+    .navbar { z-index:1100; }
+    .sidebar { position:fixed; top:70px; left:0; height:calc(100vh - 70px); width:230px; background-color:#2c2c2c; overflow-y:auto; transition:transform 0.3s ease; z-index:1000; display:flex; flex-direction:column; border-right:1px solid #444; }
+    .sidebar.collapsed { transform:translateX(-100%); }
+    .sidebar a { display:block; padding:15px 20px; color:#fff; text-decoration:none; white-space:nowrap; }
+    .sidebar a:hover { background-color:#ff4d6d; }
+    .main-content { margin-left:230px; padding:100px 20px 20px; transition:margin-left 0.3s ease; }
+    .main-content.expanded { margin-left:0; }
+    .toggle-btn,.show-sidebar-btn{ position:fixed; top:75px; z-index:1200; background-color:#ff4d6d; color:#fff; border:none; padding:5px 10px; border-radius:5px; }
+    .toggle-btn{ left:10px; }
+    .show-sidebar-btn{ left:10px; display:none; }
+    .sidebar.collapsed ~ .show-sidebar-btn{ display:block; }
+    .card{ background:linear-gradient(135deg,#2c2c2c 0%,#383838 100%); border-radius:20px; border:1px solid #444; margin-bottom:20px; box-shadow:0 10px 30px rgba(0,0,0,0.3); overflow:hidden; }
+    .card-header{ background:rgba(255,77,109,0.1); color:#fff; border-bottom:1px solid #444; padding:1.5rem; }
+    .form-control{ background-color:#3c3c3c; border:1px solid #555; color:#fff; }
+    .form-control:focus{ background-color:#3c3c3c; border-color:#ff4d6d; color:#fff; box-shadow:0 0 0 0.2rem rgba(255,77,109,0.25); }
+    .form-label{ font-weight:600; margin-bottom:8px; color:#fff; }
+    .required::after{ content:" *"; color:#ff4d6d; }
+    .btn-primary{ background-color:#ff4d6d; border-color:#ff4d6d; padding:10px 20px; font-weight:500; }
+    .btn-primary:hover{ background-color:#e63946; border-color:#e63946; }
+    .btn-secondary{ background-color:#6c757d; border-color:#6c757d; padding:10px 20px; font-weight:500; }
+    .btn-secondary:hover{ background-color:#5a6268; border-color:#545b62; }
+    .alert-danger{ background-color:#2c1618; border-color:#5c2125; color:#f8d7da; }
+    .text-danger{ color:#ff6b6b !important; }
+    .form-section{ background-color:#2a2a2a; border-radius:8px; padding:20px; margin-bottom:20px; border:1px solid #404040; }
+    .form-section-title{ color:#ff4d6d; font-weight:600; margin-bottom:15px; padding-bottom:8px; border-bottom:2px solid #ff4d6d; }
+    .page-header{ display:flex; justify-content:space-between; align-items:center; flex-wrap:wrap; gap:1rem; }
+    .page-title{ color:#fff; font-weight:600; font-size:1.75rem; }
+</style>
 @await Html.PartialAsync("_BrandManagerMenu")
 <div class="main-content" id="mainContent">
-    <div class="container">
-        <h3 class="text-white mb-4">@ViewData["Title"]</h3>
-        <form asp-action="Edit" method="post">
-            <input type="hidden" asp-for="Id" />
-            <div class="mb-3">
-                <label asp-for="Name" class="form-label"></label>
-                <input asp-for="Name" class="form-control" required />
-                <span asp-validation-for="Name" class="text-danger"></span>
+    <div class="container-fluid px-4 py-3">
+        <div class="row mb-4">
+            <div class="col-12">
+                <div class="page-header">
+                    <h2 class="page-title mb-0">
+                        <i class="fas fa-edit me-2 text-primary"></i>
+                        Chỉnh Sửa Thương Hiệu
+                    </h2>
+                </div>
             </div>
-            <div class="mb-3">
-                <label asp-for="Description" class="form-label"></label>
-                <textarea asp-for="Description" class="form-control" required></textarea>
-                <span asp-validation-for="Description" class="text-danger"></span>
+        </div>
+        <div class="row">
+            <div class="col-md-8 offset-md-2">
+                <div class="card shadow">
+                    <div class="card-body">
+                        <form asp-action="Edit" method="post" novalidate>
+                            <input type="hidden" asp-for="Id" />
+                            @await Html.PartialAsync("_BrandManagerForm")
+                            <div class="form-group text-center">
+                                <a asp-action="Index" class="btn btn-secondary me-3">
+                                    <i class="fas fa-arrow-left me-2"></i>Quay lại
+                                </a>
+                                <button type="submit" class="btn btn-primary">
+                                    <i class="fas fa-save me-2"></i>Lưu thay đổi
+                                </button>
+                            </div>
+                        </form>
+                    </div>
+                </div>
             </div>
-            <button type="submit" class="btn btn-primary">Lưu</button>
-        </form>
+        </div>
     </div>
 </div>
 @await Html.PartialAsync("_BrandManagerMenuScripts")

--- a/Netflixx/Areas/ShopSouvenir/Views/BrandManager/_BrandManagerForm.cshtml
+++ b/Netflixx/Areas/ShopSouvenir/Views/BrandManager/_BrandManagerForm.cshtml
@@ -1,0 +1,19 @@
+@model Netflixx.Models.BrandSouModel
+
+<div asp-validation-summary="ModelOnly" class="alert alert-danger" role="alert"></div>
+
+<div class="row">
+    <div class="col-md-12">
+        <div class="form-group">
+            <label asp-for="Name" class="form-label required"></label>
+            <input asp-for="Name" class="form-control" placeholder="Nhập tên thương hiệu" />
+            <span asp-validation-for="Name" class="text-danger"></span>
+        </div>
+    </div>
+</div>
+
+<div class="form-group">
+    <label asp-for="Description" class="form-label"></label>
+    <textarea asp-for="Description" class="form-control" rows="4" placeholder="Mô tả về thương hiệu..."></textarea>
+    <span asp-validation-for="Description" class="text-danger"></span>
+</div>

--- a/Netflixx/Views/Shared/_Layout.cshtml
+++ b/Netflixx/Views/Shared/_Layout.cshtml
@@ -50,6 +50,7 @@
                     <li class="nav-item"><a class="nav-link" asp-controller="Blog" asp-action="Index">Blog</a></li>
                     <li class="nav-item"><a class="nav-link" asp-area="ShopSouvenir" asp-controller="Home" asp-action="Index">Souvenir</a></li>
                     <li class="nav-item"><a class="nav-link" asp-area="ProductionManager" asp-controller="ProductionManager" asp-action="Index">List Company</a></li>
+                    <li class="nav-item"><a class="nav-link" asp-area="ShopSouvenir" asp-controller="BrandManager" asp-action="Index">List Brand</a></li>
                     <li class="nav-item"><a class="nav-link" asp-controller="Contact" asp-action="Index">Contact</a></li>
                     <li class="nav-item"><a class="nav-link" href="#">Series</a></li>
                     <li class="nav-item"><a class="nav-link" href="#">Categories</a></li>


### PR DESCRIPTION
## Summary
- add a dedicated `_BrandManagerForm` partial for form fields
- restyle BrandManager create/edit/detail/delete pages following ProductionManager design
- add "List Brand" entry to main navigation menu

## Testing
- `npm run scss` *(fails: `sass` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877ab9d06f48326901101c286d32eb6