### PR TITLE
Fix ShopSouvenir add-to-cart

### DIFF
--- a/Netflixx/Areas/ShopSouvenir/Controllers/CartController.cs
+++ b/Netflixx/Areas/ShopSouvenir/Controllers/CartController.cs
@@ -37,27 +37,27 @@ namespace Netflixx.Areas.ShopSouvenir.Controllers
             return View(model);
         }
 
-        [HttpPost("AddToCart/{id}/{quantity?}")]
-        public async Task<IActionResult> AddToCart(int id, int quantity = 1)
+        [HttpPost("AddToCart")]
+        public async Task<IActionResult> AddToCart([FromBody] AddToCartRequest request)
         {
             try
             {
-                var product = await _context.ProductSous.FindAsync(id);
+                var product = await _context.ProductSous.FindAsync(request.Id);
                 if (product == null)
                 {
                     return Json(new { success = false, message = "Product not found" });
                 }
 
                 var cart = HttpContext.Session.GetJson<List<CartModel>>("cart") ?? new List<CartModel>();
-                var item = cart.FirstOrDefault(x => x.ProductId == id);
+                var item = cart.FirstOrDefault(x => x.ProductId == request.Id);
 
                 if (item == null)
                 {
-                    cart.Add(new CartModel(product) { Quantity = quantity });
+                    cart.Add(new CartModel(product) { Quantity = request.Quantity });
                 }
                 else
                 {
-                    item.Quantity += quantity;
+                    item.Quantity += request.Quantity;
                 }
 
                 HttpContext.Session.SetJson("cart", cart);

--- a/Netflixx/Areas/ShopSouvenir/Models/AddToCartRequest.cs
+++ b/Netflixx/Areas/ShopSouvenir/Models/AddToCartRequest.cs
@@ -1,0 +1,13 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Netflixx.Areas.ShopSouvenir.Models
+{
+    public class AddToCartRequest
+    {
+        [Required]
+        public int Id { get; set; }
+
+        [Range(1, int.MaxValue)]
+        public int Quantity { get; set; } = 1;
+    }
+}


### PR DESCRIPTION
## Summary
- add `AddToCartRequest` model for incoming JSON payloads
- update `CartController.AddToCart` to use request model and compute totals

## Testing
- `dotnet test Netflixx.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877c034251883268b7895460d0b6512