### PR TITLE
Display brand icons

### DIFF
--- a/Netflixx/Areas/ShopSouvenir/Views/Brand/Index.cshtml
+++ b/Netflixx/Areas/ShopSouvenir/Views/Brand/Index.cshtml
@@ -38,12 +38,12 @@
                     <td>
                         <div class="btn-group" role="group">
                             <a asp-action="Edit" asp-route-BrandId="@brand.Id"
-                               class="btn btn-sm btn-warning">
-                                <i class="fas fa-edit"></i>
+                               class="btn btn-sm btn-warning" title="Chỉnh sửa">
+                                <i class="fa-solid fa-pen-to-square"></i>
                             </a>
                             <a asp-action="Remove" asp-route-BrandId="@brand.Id"
-                               class="btn btn-sm btn-danger confirmDeletion">
-                                <i class="fas fa-trash"></i>
+                               class="btn btn-sm btn-danger confirmDeletion" title="Xóa">
+                                <i class="fa-solid fa-trash"></i>
                             </a>
                         </div>
                     </td>

--- a/Netflixx/Areas/ShopSouvenir/Views/_ViewStart.cshtml
+++ b/Netflixx/Areas/ShopSouvenir/Views/_ViewStart.cshtml
@@ -1,0 +1,3 @@
+@{
+    Layout = "_Layout";
+}


### PR DESCRIPTION
## Summary
- add area `_ViewStart` for ShopSouvenir so admin layout is used
- update Brand index to use FontAwesome icons for edit/delete

## Testing
- `npm install`
- `npm run scss`


------
https://chatgpt.com/codex/tasks/task_e_6877c6a707a883269b4942bdb35abcc9