### PR TITLE
Display account info in souvenir cart

### DIFF
--- a/Netflixx/Areas/ShopSouvenir/Views/Cart/Index.cshtml
+++ b/Netflixx/Areas/ShopSouvenir/Views/Cart/Index.cshtml
@@ -1,4 +1,26 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
+@using Microsoft.AspNetCore.Identity
+@using Microsoft.EntityFrameworkCore
+@using Netflixx.Models
+@using Netflixx.Repositories
+@inject UserManager<AppUserModel> UserManager
+@inject DBContext DBContext
+@using Netflixx.Areas.ShopSouvenir.Models
+@model CartViewModel
+@{
+    string accountName = "";
+    int coins = 0;
+    var currentUser = await UserManager.GetUserAsync(User);
+    if (currentUser != null)
+    {
+        accountName = currentUser.UserName ?? "";
+        var account = await DBContext.UserAccounts.FirstOrDefaultAsync(a => a.UserID == currentUser.Id);
+        if (account != null)
+        {
+            coins = account.PointsBalance;
+        }
+    }
+}
 <html lang="en">
 <head>
     <title>Shoping Cart</title>
@@ -244,7 +266,9 @@
                 <span class="mtext-103 cl2">
                     Your Cart
                 </span>
-
+                <div class="p-t-5">
+                    @accountName - <i class="zmdi zmdi-money"></i> @coins coins
+                </div>
                 <div class="fs-35 lh-10 cl2 p-lr-5 pointer hov-cl1 trans-04 js-hide-cart">
                     <i class="zmdi zmdi-close"></i>
                 </div>
@@ -337,9 +361,6 @@
 
 
     <!-- Shoping Cart -->
-    @using Netflixx.Areas.ShopSouvenir.Models
-    @model CartViewModel
-    <div class="bg0 p-t-75 p-b-85">
         <div class="container">
             @if (Model.CartItems != null && Model.CartItems.Count > 0)
             {

--- a/Netflixx/Areas/ShopSouvenir/Views/Home/Index.cshtml
+++ b/Netflixx/Areas/ShopSouvenir/Views/Home/Index.cshtml
@@ -1,6 +1,26 @@
-﻿@model IEnumerable<Netflixx.Models.Souvenir.ProductSouModel>
+@using Microsoft.AspNetCore.Identity
+@using Microsoft.EntityFrameworkCore
+@using Netflixx.Models
+@using Netflixx.Repositories
+@inject UserManager<AppUserModel> UserManager
+@inject DBContext DBContext
+@model IEnumerable<Netflixx.Models.Souvenir.ProductSouModel>
 @{
     Layout = null;
+}
+@{
+    string accountName = "";
+    int coins = 0;
+    var currentUser = await UserManager.GetUserAsync(User);
+    if (currentUser != null)
+    {
+        accountName = currentUser.UserName ?? "";
+        var account = await DBContext.UserAccounts.FirstOrDefaultAsync(a => a.UserID == currentUser.Id);
+        if (account != null)
+        {
+            coins = account.PointsBalance;
+        }
+    }
 }
 <!DOCTYPE html>
 <html lang="en">
@@ -289,7 +309,9 @@
                 <span class="mtext-103 cl2">
                     Your Cart
                 </span>
-
+                <div class="p-t-5">
+                    @accountName - <i class="zmdi zmdi-money"></i> @coins coins
+                </div>
                 <div class="fs-35 lh-10 cl2 p-lr-5 pointer hov-cl1 trans-04 js-hide-cart">
                     <i class="zmdi zmdi-close"></i>
                 </div>

--- a/Netflixx/Areas/ShopSouvenir/Views/Product/Index.cshtml
+++ b/Netflixx/Areas/ShopSouvenir/Views/Product/Index.cshtml
@@ -1,5 +1,25 @@
-﻿@{
+@using Microsoft.AspNetCore.Identity
+@using Microsoft.EntityFrameworkCore
+@using Netflixx.Models
+@using Netflixx.Repositories
+@inject UserManager<AppUserModel> UserManager
+@inject DBContext DBContext
+@{
 	Layout = null;
+}
+@{
+    string accountName = "";
+    int coins = 0;
+    var currentUser = await UserManager.GetUserAsync(User);
+    if (currentUser != null)
+    {
+        accountName = currentUser.UserName ?? "";
+        var account = await DBContext.UserAccounts.FirstOrDefaultAsync(a => a.UserID == currentUser.Id);
+        if (account != null)
+        {
+            coins = account.PointsBalance;
+        }
+    }
 }
 <!DOCTYPE html>
 <html lang="en">
@@ -249,15 +269,17 @@
 		<div class="s-full js-hide-cart"></div>
 
 		<div class="header-cart flex-col-l p-l-65 p-r-25">
-			<div class="header-cart-title flex-w flex-sb-m p-b-8">
-				<span class="mtext-103 cl2">
-					Your Cart
-				</span>
-
-				<div class="fs-35 lh-10 cl2 p-lr-5 pointer hov-cl1 trans-04 js-hide-cart">
-					<i class="zmdi zmdi-close"></i>
-				</div>
-			</div>
+                        <div class="header-cart-title flex-w flex-sb-m p-b-8">
+                                <span class="mtext-103 cl2">
+                                        Your Cart
+                                </span>
+                                <div class="p-t-5">
+                                        @accountName - <i class="zmdi zmdi-money"></i> @coins coins
+                                </div>
+                                <div class="fs-35 lh-10 cl2 p-lr-5 pointer hov-cl1 trans-04 js-hide-cart">
+                                        <i class="zmdi zmdi-close"></i>
+                                </div>
+                        </div>
 
 			<div class="header-cart-content flex-w js-pscroll">
 				<ul class="header-cart-wrapitem w-full">


### PR DESCRIPTION
## Summary
- fetch logged in account and coin balance for ShopSouvenir views
- show account name and coins in header cart panel

## Testing
- `dotnet build Netflixx.sln`

------
https://chatgpt.com/codex/tasks/task_e_6877c60cd6b08326818f491448f5c0e5