### PR TITLE
Add POST delete for brands

### DIFF
--- a/Netflixx/Areas/ShopSouvenir/Controllers/BrandController.cs
+++ b/Netflixx/Areas/ShopSouvenir/Controllers/BrandController.cs
@@ -84,6 +84,8 @@ namespace Netflixx.Areas.ShopSouvenir.Controllers
             return RedirectToAction("Index");
         }
 
+        [HttpPost]
+        [ValidateAntiForgeryToken]
         public async Task<IActionResult> Remove(int BrandId)
         {
             var brand = await _context.BrandSous.FindAsync(BrandId);
@@ -91,7 +93,7 @@ namespace Netflixx.Areas.ShopSouvenir.Controllers
             {
                 _context.BrandSous.Remove(brand);
                 await _context.SaveChangesAsync();
-                TempData["error"] = "Xóa thương hiệu thành công";
+                TempData["success"] = "Xóa thương hiệu thành công";
             }
             else
             {

--- a/Netflixx/Areas/ShopSouvenir/Views/Brand/Index.cshtml
+++ b/Netflixx/Areas/ShopSouvenir/Views/Brand/Index.cshtml
@@ -41,10 +41,11 @@
                                class="btn btn-sm btn-warning">
                                 <i class="fas fa-edit"></i>
                             </a>
-                            <a asp-action="Remove" asp-route-BrandId="@brand.Id"
-                               class="btn btn-sm btn-danger confirmDeletion">
-                                <i class="fas fa-trash"></i>
-                            </a>
+                            <form asp-action="Remove" asp-route-BrandId="@brand.Id" method="post" class="d-inline">
+                                <button type="submit" class="btn btn-sm btn-danger confirmDeletion">
+                                    <i class="fas fa-trash"></i>
+                                </button>
+                            </form>
                         </div>
                     </td>
                 </tr>
@@ -57,8 +58,10 @@
     <script>
         $(document).ready(function() {
             // Xác nhận xóa
-            $('.confirmDeletion').click(function() {
-                return confirm('Bạn có chắc chắn muốn xóa loại mô hình này?');
+            $('.confirmDeletion').click(function(e) {
+                if (!confirm('Bạn có chắc chắn muốn xóa thương hiệu này?')) {
+                    e.preventDefault();
+                }
             });
 
             // DataTable


### PR DESCRIPTION
## Summary
- use POST method for deleting brands
- adjust brand list to post delete form
- tweak client-side confirmation logic

## Testing
- `npm test` *(fails: Missing script)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877ccdbbf2c8326b93a9b907f0b8d70