### PR TITLE
Fix AddToCart form submission

### DIFF
--- a/Netflixx/Areas/ShopSouvenir/Controllers/CartController.cs
+++ b/Netflixx/Areas/ShopSouvenir/Controllers/CartController.cs
@@ -45,7 +45,7 @@ namespace Netflixx.Areas.ShopSouvenir.Controllers
         }
 
         [HttpPost("AddToCart")]
-        public async Task<IActionResult> AddToCart([FromBody] AddToCartRequest request)
+        public async Task<IActionResult> AddToCart(AddToCartRequest request)
         {
             try
             {


### PR DESCRIPTION
## Summary
- allow ShopSouvenir AddToCart endpoint to bind from both JSON and form data

## Testing
- `dotnet build Netflixx.sln`

------
https://chatgpt.com/codex/tasks/task_e_6877cf4f21ac8326bbd0333bb6f896c6