### PR TITLE
Add DataTables and delete confirm for brand index

### DIFF
--- a/Netflixx/Areas/ShopSouvenir/Views/Brand/Index.cshtml
+++ b/Netflixx/Areas/ShopSouvenir/Views/Brand/Index.cshtml
@@ -1,7 +1,6 @@
 @model IEnumerable<Netflixx.Models.BrandSouModel>
 @{
     ViewData["Title"] = "Brand Management";
-    Layout = null;
 }
 <!DOCTYPE html>
 <html lang="en">
@@ -9,6 +8,7 @@
     <meta charset="utf-8" />
     <title>@ViewData["Title"]</title>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.6.2/dist/css/bootstrap.min.css" />
+    <link rel="stylesheet" href="https://cdn.datatables.net/1.13.6/css/jquery.dataTables.min.css" />
 </head>
 <body>
     <div class="container mt-4">
@@ -16,7 +16,7 @@
         <p>
             <a asp-action="Create" class="btn btn-primary">Create New Brand</a>
         </p>
-        <table class="table table-bordered">
+        <table id="brandTable" class="table table-bordered">
             <thead>
                 <tr>
                     <th>Name</th>
@@ -39,5 +39,26 @@
             </tbody>
         </table>
     </div>
+
+    <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+    <script src="https://cdn.datatables.net/1.13.6/js/jquery.dataTables.min.js"></script>
+    <script>
+        $(document).ready(function () {
+            $('#brandTable').DataTable({
+                responsive: true,
+                language: {
+                    url: '//cdn.datatables.net/plug-ins/1.13.6/i18n/vi.json'
+                },
+                dom: '<"top"f>rt<"bottom"lip><"clear">',
+                pageLength: 10
+            });
+
+            $('.btn-danger').click(function (e) {
+                if (!confirm('Bạn có chắc chắn muốn xóa thương hiệu này?')) {
+                    e.preventDefault();
+                }
+            });
+        });
+    </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- enhance brand index by enabling DataTables and confirm deletion

## Testing
- `npm install`
- `npm run scss`

------
https://chatgpt.com/codex/tasks/task_e_6877e9dc0880832680f3d2fecd5c60e8