### PR TITLE
Improve BrandManager UI

### DIFF
--- a/Netflixx/Views/BrandManager/Create.cshtml
+++ b/Netflixx/Views/BrandManager/Create.cshtml
@@ -2,21 +2,35 @@
 @{
     ViewData["Title"] = "Create Brand";
 }
-<h1>Create Brand</h1>
-<form asp-action="Create" method="post">
-    <div class="mb-3">
-        <label asp-for="Name" class="form-label"></label>
-        <input asp-for="Name" class="form-control" />
-        <span asp-validation-for="Name" class="text-danger"></span>
+<div class="brand-manager-page container">
+    <div class="card brand-manager-card">
+        <div class="card-header">
+            <h2 class="mb-0">Create Brand</h2>
+        </div>
+        <div class="card-body">
+            <form asp-action="Create" method="post">
+                <div class="mb-3">
+                    <label asp-for="Name" class="form-label"></label>
+                    <input asp-for="Name" class="form-control" />
+                    <span asp-validation-for="Name" class="text-danger"></span>
+                </div>
+                <div class="mb-3">
+                    <label asp-for="Description" class="form-label"></label>
+                    <textarea asp-for="Description" class="form-control"></textarea>
+                    <span asp-validation-for="Description" class="text-danger"></span>
+                </div>
+                <div class="text-end">
+                    <button type="submit" class="btn btn-danger">Create</button>
+                    <a asp-action="Index" class="btn btn-secondary">Back to List</a>
+                </div>
+            </form>
+        </div>
     </div>
-    <div class="mb-3">
-        <label asp-for="Description" class="form-label"></label>
-        <textarea asp-for="Description" class="form-control"></textarea>
-        <span asp-validation-for="Description" class="text-danger"></span>
-    </div>
-    <button type="submit" class="btn btn-primary">Create</button>
-    <a asp-action="Index" class="btn btn-secondary">Back to List</a>
-</form>
+</div>
+
+@section Styles {
+    <link rel="stylesheet" href="~/css/brand-manager.css" asp-append-version="true" />
+}
 @section Scripts {
     @{await Html.RenderPartialAsync("_ValidationScriptsPartial");}
 }

--- a/Netflixx/Views/BrandManager/Delete.cshtml
+++ b/Netflixx/Views/BrandManager/Delete.cshtml
@@ -2,14 +2,24 @@
 @{
     ViewData["Title"] = "Delete Brand";
 }
-<h1>Delete Brand</h1>
-<h3>Are you sure you want to delete this?</h3>
-<div>
-    <h4>@Model.Name</h4>
-    <p>@Model.Description</p>
+<div class="brand-manager-page container">
+    <div class="card brand-manager-card">
+        <div class="card-header">
+            <h2 class="mb-0">Delete Brand</h2>
+        </div>
+        <div class="card-body">
+            <h5 class="mb-3">Are you sure you want to delete this?</h5>
+            <h4>@Model.Name</h4>
+            <p>@Model.Description</p>
+            <form asp-action="Delete" method="post" class="mt-3">
+                <input type="hidden" asp-for="Id" />
+                <button type="submit" class="btn btn-danger">Delete</button>
+                <a asp-action="Index" class="btn btn-secondary">Back to List</a>
+            </form>
+        </div>
+    </div>
 </div>
-<form asp-action="Delete" method="post">
-    <input type="hidden" asp-for="Id" />
-    <button type="submit" class="btn btn-danger">Delete</button>
-    <a asp-action="Index" class="btn btn-secondary">Back to List</a>
-</form>
+
+@section Styles {
+    <link rel="stylesheet" href="~/css/brand-manager.css" asp-append-version="true" />
+}

--- a/Netflixx/Views/BrandManager/Details.cshtml
+++ b/Netflixx/Views/BrandManager/Details.cshtml
@@ -2,14 +2,24 @@
 @{
     ViewData["Title"] = "Brand Details";
 }
-<h1>Brand Details</h1>
-<div>
-    <dl class="row">
-        <dt class="col-sm-2">Name</dt>
-        <dd class="col-sm-10">@Model.Name</dd>
-        <dt class="col-sm-2">Description</dt>
-        <dd class="col-sm-10">@Model.Description</dd>
-    </dl>
+<div class="brand-manager-page container">
+    <div class="card brand-manager-card">
+        <div class="card-header">
+            <h2 class="mb-0">Brand Details</h2>
+        </div>
+        <div class="card-body">
+            <dl class="row mb-3">
+                <dt class="col-sm-3">Name</dt>
+                <dd class="col-sm-9">@Model.Name</dd>
+                <dt class="col-sm-3">Description</dt>
+                <dd class="col-sm-9">@Model.Description</dd>
+            </dl>
+            <a asp-action="Edit" asp-route-id="@Model.Id" class="btn btn-warning">Edit</a>
+            <a asp-action="Index" class="btn btn-secondary">Back to List</a>
+        </div>
+    </div>
 </div>
-<a asp-action="Edit" asp-route-id="@Model.Id" class="btn btn-primary">Edit</a>
-<a asp-action="Index" class="btn btn-secondary">Back to List</a>
+
+@section Styles {
+    <link rel="stylesheet" href="~/css/brand-manager.css" asp-append-version="true" />
+}

--- a/Netflixx/Views/BrandManager/Edit.cshtml
+++ b/Netflixx/Views/BrandManager/Edit.cshtml
@@ -2,22 +2,36 @@
 @{
     ViewData["Title"] = "Edit Brand";
 }
-<h1>Edit Brand</h1>
-<form asp-action="Edit" method="post">
-    <input type="hidden" asp-for="Id" />
-    <div class="mb-3">
-        <label asp-for="Name" class="form-label"></label>
-        <input asp-for="Name" class="form-control" />
-        <span asp-validation-for="Name" class="text-danger"></span>
+<div class="brand-manager-page container">
+    <div class="card brand-manager-card">
+        <div class="card-header">
+            <h2 class="mb-0">Edit Brand</h2>
+        </div>
+        <div class="card-body">
+            <form asp-action="Edit" method="post">
+                <input type="hidden" asp-for="Id" />
+                <div class="mb-3">
+                    <label asp-for="Name" class="form-label"></label>
+                    <input asp-for="Name" class="form-control" />
+                    <span asp-validation-for="Name" class="text-danger"></span>
+                </div>
+                <div class="mb-3">
+                    <label asp-for="Description" class="form-label"></label>
+                    <textarea asp-for="Description" class="form-control"></textarea>
+                    <span asp-validation-for="Description" class="text-danger"></span>
+                </div>
+                <div class="text-end">
+                    <button type="submit" class="btn btn-danger">Save</button>
+                    <a asp-action="Index" class="btn btn-secondary">Back to List</a>
+                </div>
+            </form>
+        </div>
     </div>
-    <div class="mb-3">
-        <label asp-for="Description" class="form-label"></label>
-        <textarea asp-for="Description" class="form-control"></textarea>
-        <span asp-validation-for="Description" class="text-danger"></span>
-    </div>
-    <button type="submit" class="btn btn-primary">Save</button>
-    <a asp-action="Index" class="btn btn-secondary">Back to List</a>
-</form>
+</div>
+
+@section Styles {
+    <link rel="stylesheet" href="~/css/brand-manager.css" asp-append-version="true" />
+}
 @section Scripts {
     @{await Html.RenderPartialAsync("_ValidationScriptsPartial");}
 }

--- a/Netflixx/Views/BrandManager/Index.cshtml
+++ b/Netflixx/Views/BrandManager/Index.cshtml
@@ -2,30 +2,40 @@
 @{
     ViewData["Title"] = "Brand List";
 }
-<h1>Brand List</h1>
-<p>
-    <a asp-action="Create" class="btn btn-primary">Create New</a>
-</p>
-<table class="table table-striped">
-    <thead>
-        <tr>
-            <th>Name</th>
-            <th>Description</th>
-            <th></th>
-        </tr>
-    </thead>
-    <tbody>
-        @foreach (var item in Model)
-        {
-            <tr>
-                <td>@item.Name</td>
-                <td>@item.Description</td>
-                <td>
-                    <a asp-action="Edit" asp-route-id="@item.Id" class="btn btn-sm btn-warning">Edit</a>
-                    <a asp-action="Details" asp-route-id="@item.Id" class="btn btn-sm btn-info">Details</a>
-                    <a asp-action="Delete" asp-route-id="@item.Id" class="btn btn-sm btn-danger">Delete</a>
-                </td>
-            </tr>
-        }
-    </tbody>
-</table>
+<div class="brand-manager-page container">
+    <div class="card brand-manager-card">
+        <div class="card-header d-flex justify-content-between align-items-center">
+            <h2 class="mb-0">Brand List</h2>
+            <a asp-action="Create" class="btn btn-danger">Create New</a>
+        </div>
+        <div class="card-body p-0">
+            <table class="table table-hover mb-0 brand-manager-table">
+                <thead>
+                    <tr>
+                        <th>Name</th>
+                        <th>Description</th>
+                        <th style="width:150px"></th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach (var item in Model)
+                    {
+                        <tr>
+                            <td>@item.Name</td>
+                            <td>@item.Description</td>
+                            <td>
+                                <a asp-action="Edit" asp-route-id="@item.Id" class="btn btn-sm btn-warning">Edit</a>
+                                <a asp-action="Details" asp-route-id="@item.Id" class="btn btn-sm btn-info">Details</a>
+                                <a asp-action="Delete" asp-route-id="@item.Id" class="btn btn-sm btn-danger">Delete</a>
+                            </td>
+                        </tr>
+                    }
+                </tbody>
+            </table>
+        </div>
+    </div>
+</div>
+
+@section Styles {
+    <link rel="stylesheet" href="~/css/brand-manager.css" asp-append-version="true" />
+}

--- a/Netflixx/wwwroot/css/brand-manager.css
+++ b/Netflixx/wwwroot/css/brand-manager.css
@@ -1,0 +1,25 @@
+.brand-manager-page {
+    padding-top: 70px;
+}
+
+.brand-manager-card {
+    background-color: #1f1f1f;
+    color: #fff;
+    border-radius: 8px;
+    box-shadow: 0 4px 10px rgba(0,0,0,0.3);
+}
+
+.brand-manager-card label {
+    color: #ccc;
+}
+
+.brand-manager-card .form-control,
+.brand-manager-card textarea {
+    background-color: #333;
+    border-color: #444;
+    color: #fff;
+}
+
+.brand-manager-table th {
+    color: #e50914;
+}


### PR DESCRIPTION
## Summary
- add dedicated CSS for BrandManager pages
- redesign BrandManager views using Bootstrap cards and dark theme styles

## Testing
- `npm install`
- `npm run scss`

------
https://chatgpt.com/codex/tasks/task_e_6877f0bb3b7083268bf31553d8b87dc5