### PR TITLE
Center BrandManager pages and add delete modal

### DIFF
--- a/Netflixx/Views/BrandManager/Index.cshtml
+++ b/Netflixx/Views/BrandManager/Index.cshtml
@@ -245,7 +245,7 @@
                             <td>
                                 <div class="action-buttons">
                                     <a asp-action="Edit" asp-route-id="@item.Id" class="btn-edit">Edit</a>
-                                    <a asp-action="Delete" asp-route-id="@item.Id" class="btn-delete">Delete</a>
+                                    <a asp-action="Delete" asp-route-id="@item.Id" class="btn-delete" data-id="@item.Id" data-name="@item.Name">Delete</a>
                                 </div>
                             </td>
                         </tr>
@@ -343,5 +343,44 @@
         });
 
         clearButton.addEventListener('click', clearSearch);
+    });
+</script>
+
+<!-- Delete Confirmation Modal -->
+<div class="modal fade" id="deleteModal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title">Delete Brand</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                <p>Are you sure you want to delete <strong id="brandNameToDelete"></strong>?</p>
+            </div>
+            <div class="modal-footer">
+                <form id="deleteForm" method="post" asp-action="Delete">
+                    <input type="hidden" id="brandIdToDelete" name="id" />
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                    <button type="submit" class="btn btn-danger">Delete</button>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>
+
+<script>
+    document.addEventListener('DOMContentLoaded', function () {
+        document.querySelectorAll('.btn-delete').forEach(btn => {
+            btn.addEventListener('click', function (e) {
+                e.preventDefault();
+                const id = this.getAttribute('data-id');
+                const name = this.getAttribute('data-name');
+                document.getElementById('brandIdToDelete').value = id;
+                document.getElementById('brandNameToDelete').textContent = name;
+                document.getElementById('deleteForm').setAttribute('action', '/BrandManager/Delete/' + id);
+                const modal = new bootstrap.Modal(document.getElementById('deleteModal'));
+                modal.show();
+            });
+        });
     });
 </script>

--- a/Netflixx/wwwroot/css/brand-manager.css
+++ b/Netflixx/wwwroot/css/brand-manager.css
@@ -1,0 +1,12 @@
+.brand-manager-page {
+    min-height: calc(100vh - 80px);
+    padding-top: 60px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
+.brand-manager-card {
+    width: 100%;
+    max-width: 600px;
+}


### PR DESCRIPTION
## Summary
- add CSS to center BrandManager card layouts
- use data attributes on delete links
- show a Bootstrap modal to confirm deletions

## Testing
- `npm run scss`

------
https://chatgpt.com/codex/tasks/task_e_6877fbca63a0832686f4df6ee0adff22