### PR TITLE
Fix missing brand name in delete alert

### DIFF
--- a/Netflixx/Controllers/BrandManagerController.cs
+++ b/Netflixx/Controllers/BrandManagerController.cs
@@ -89,7 +89,7 @@ namespace Netflixx.Controllers
             {
                 _context.BrandSous.Remove(brand);
                 await _context.SaveChangesAsync();
-                TempData["success"] = "Brand deleted successfully";
+                TempData["success"] = $"Brand '{brand.Name}' deleted successfully";
             }
             return RedirectToAction(nameof(Index));
         }


### PR DESCRIPTION
## Summary
- show brand name in success message after deleting a brand

## Testing
- `dotnet build Netflixx/Netflixx.csproj`

------
https://chatgpt.com/codex/tasks/task_e_6877ffa0320883269d4b4d491dbe01d1