### PR TITLE
Fix BrandManager text color

### DIFF
--- a/Netflixx/wwwroot/css/brand-manager.css
+++ b/Netflixx/wwwroot/css/brand-manager.css
@@ -9,4 +9,9 @@
 .brand-manager-card {
     width: 100%;
     max-width: 600px;
+    color: #000 !important;
+}
+
+.brand-manager-card .btn {
+    color: #fff !important;
 }


### PR DESCRIPTION
## Summary
- adjust BrandManager style so text appears in black

## Testing
- `npm run scss`

------
https://chatgpt.com/codex/tasks/task_e_687804fce5388326a1defedf3fdc090a