### PR TITLE
Fix BrandManager delete button text color

### DIFF
--- a/Netflixx/Views/BrandManager/Index.cshtml
+++ b/Netflixx/Views/BrandManager/Index.cshtml
@@ -214,7 +214,7 @@
 
     .btn-delete {
         background-color: #ef4444;
-        color: white;
+        color: black;
         padding: 0.25rem 0.75rem;
         border: none;
         border-radius: 0.25rem;
@@ -226,7 +226,7 @@
 
         .btn-delete:hover {
             background-color: #dc2626;
-            color: white;
+            color: black;
             text-decoration: none;
         }
 

--- a/Netflixx/wwwroot/css/brand-manager.css
+++ b/Netflixx/wwwroot/css/brand-manager.css
@@ -13,5 +13,5 @@
 }
 
 .brand-manager-card .btn {
-    color: #fff !important;
+    color: #000 !important;
 }


### PR DESCRIPTION
## Summary
- change Delete button text color to black in BrandManager list
- override BrandManager page button color to black

## Testing
- `npm install`
- `npm run scss`


------
https://chatgpt.com/codex/tasks/task_e_6878070713b083269c46d23ab24a7104