### PR TITLE
Fix text color in BrandManager delete modal

### DIFF
--- a/Netflixx/Views/BrandManager/Index.cshtml
+++ b/Netflixx/Views/BrandManager/Index.cshtml
@@ -616,7 +616,7 @@
                 <h5 class="modal-title">Delete Brand</h5>
                 <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
             </div>
-            <div class="modal-body">
+            <div class="modal-body text-black">
                 <p>Are you sure you want to delete <strong id="brandNameToDelete"></strong>?</p>
                 <p id="brandDescriptionToDelete" class="text-muted"></p>
             </div>


### PR DESCRIPTION
## Summary
- set modal body text to black in BrandManager delete dialog

## Testing
- `dotnet build Netflixx/Netflixx.csproj`

------
https://chatgpt.com/codex/tasks/task_e_68784212d2f48326b2324f68ce582627