### PR TITLE
Remove VietQR payment option

### DIFF
--- a/Netflixx/Views/Filmpackage/Buy.cshtml
+++ b/Netflixx/Views/Filmpackage/Buy.cshtml
@@ -6,19 +6,6 @@
     string username = User.Identity.Name;
 
 
-    // Thông tin ngân hàng
-    string bankId = "970454";
-    string accountNo = "9021625262901";
-    string template = "compact";
-    string amount = Model.PackagePrice.ToString();
-    string description = $"{username}";
-    string accountName = "NGO VAN DUC";
-
-    // Tạo link QR thanh toán
-    string qrUrl = $"https://img.vietqr.io/image/{bankId}-{accountNo}-{template}.png" +
-                   $"?amount={amount}" +
-                   $"&addInfo={Uri.EscapeDataString(description)}" +
-                   $"&accountName={Uri.EscapeDataString(accountName)}";
 
     string packageClass = Model.PackageName switch
     {
@@ -162,56 +149,20 @@
 
         @if (Model.PackagePrice > 0)
         {
-            <p>Quét mã QR bằng app ngân hàng để thanh toán:</p>
-            <img class="qr-image" src="@qrUrl" alt="QR thanh toán VietQR" />
+            <form asp-action="BuyWithCoins" method="post">
+                <input type="hidden" name="packageId" value="@Model.PackageId" />
+                <button type="submit" class="check-payment-btn">Xác nhận mua bằng coins</button>
+            </form>
         }
         else
         {
             <p class="free-package-message">Đây là gói miễn phí. Bạn có thể sử dụng ngay.</p>
         }
 
-
         <a asp-action="Index" asp-controller="Filmpackage" class="back-btn">Quay lại</a>
-        <button id="checkPaymentBtn" class="check-payment-btn">✅ Tôi đã thanh toán</button>
-        <form asp-action="BuyWithCoins" method="post" style="display:inline;">
-            <input type="hidden" name="packageId" value="@Model.PackageId" />
-            <button type="submit" class="check-payment-btn">💰 Mua bằng coins</button>
-        </form>
 
-        <div id="paymentResult" style="margin-top: 1rem; font-weight: bold;"></div>
 
 
     </div>
 </body>
 </html>
-<script>
-    document.getElementById("checkPaymentBtn").addEventListener("click", async function () {
-        const price = @Model.PackagePrice;
-        const content = "@username";
-        const resultElement = document.getElementById("paymentResult");
-
-        try {
-            const response = await fetch(
-
-                "https://script.google.com/macros/s/AKfycbyi5nMWfuHp3BigdOV9h0lq97ci0f1YTWOlULUsRgkW8_AT0e34FVu67ao3l00EXOHx/exec"
-
-            );
-            const data = await response.json();
-            const lastPaid = data.data[data.data.length - 1];
-            const lastPrice = parseInt(lastPaid["Giá trị"]);
-            const lastContent = lastPaid["Mô tả"];
-
-            if (lastPrice == price && lastContent.includes(content)) {
-                resultElement.style.color = "lime";
-                resultElement.textContent = "✅ Thanh toán thành công!";
-            } else {
-                resultElement.style.color = "orange";
-                resultElement.textContent = "⚠️ Chưa nhận được thanh toán. Vui lòng thử lại sau vài phút.";
-            }
-        } catch (e) {
-            console.error("Lỗi", e);
-            resultElement.style.color = "red";
-            resultElement.textContent = "❌ Đã xảy ra lỗi khi kiểm tra thanh toán.";
-        }
-    });
-</script>

--- a/Netflixx/Views/Filmpackage/Index.cshtml
+++ b/Netflixx/Views/Filmpackage/Index.cshtml
@@ -50,9 +50,35 @@
                 }
                 else
                 {
-                    <a asp-action="Buy" asp-route-packageId="@p.Id" asp-route-packageName="@p.Name" asp-route-packagePrice="@p.Price" class="btn btn-primary w-75 mb-3">Mua gói</a>
+                    <form asp-action="BuyWithCoins" method="post" class="buy-form">
+                        <input type="hidden" name="packageId" value="@p.Id" />
+                        <button type="submit" class="btn btn-primary w-75 mb-3">Mua gói</button>
+                    </form>
                 }
             </div>
         }
     </div>
 </main>
+
+@section Scripts {
+    @await Html.PartialAsync("_NotificationPartial")
+    <script>
+        document.querySelectorAll('.buy-form').forEach(function(form) {
+            form.addEventListener('submit', function (e) {
+                e.preventDefault();
+                Swal.fire({
+                    title: 'Xác nhận mua gói?',
+                    icon: 'question',
+                    showCancelButton: true,
+                    confirmButtonColor: '#e50914',
+                    confirmButtonText: 'Mua',
+                    cancelButtonText: 'Hủy'
+                }).then(function (result) {
+                    if (result.isConfirmed) {
+                        form.submit();
+                    }
+                });
+            });
+        });
+    </script>
+}


### PR DESCRIPTION
## Summary
- use direct coin purchases in Film Package index
- show confirmation when buying
- simplify package purchase page to remove VietQR payment

## Testing
- `npm run scss`
- `dotnet build Netflixx.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68785d482494832695577c6578013d30