### PR TITLE
Fix film names missing in package listing

### DIFF
--- a/Netflixx/Controllers/FilmpackageController.cs
+++ b/Netflixx/Controllers/FilmpackageController.cs
@@ -24,6 +24,7 @@ namespace Netflixx.Controllers
         {
             var packages = await _context.Packages
                 .Include(p => p.PackageFilms)
+                    .ThenInclude(pf => pf.Film)
                 .AsNoTracking()
                 .OrderBy(p => p.Name)
                 .ToListAsync();


### PR DESCRIPTION
## Summary
- eagerly load related Film entities when listing packages

## Testing
- `npm run scss`
- `dotnet build Netflixx.sln`

------
https://chatgpt.com/codex/tasks/task_e_6879b8da6fe88326aaf5d622191873c7