### PR TITLE
Fix package purchase checks

### DIFF
--- a/Netflixx/Views/Film/Detail.cshtml
+++ b/Netflixx/Views/Film/Detail.cshtml
@@ -12,9 +12,20 @@
 @{
     var user = await _userManager.GetUserAsync(User);
     var hasPurchased = false;
+    var hasPackage = false;
     if (user != null)
     {
         hasPurchased = await DBContext.FilmPurchases.AnyAsync(p => p.UserID == user.Id && p.FilmID == Model.Film.Id);
+
+        hasPackage = await DBContext.PackageSubscriptions
+            .Where(ps => ps.UserID == user.Id
+                         && ps.StartDate <= DateTime.UtcNow
+                         && ps.EndDate >= DateTime.UtcNow)
+            .Join(DBContext.PackageFilms.Where(pf => pf.FilmID == Model.Film.Id),
+                  ps => ps.PackageID,
+                  pf => pf.PackageID,
+                  (ps, pf) => ps)
+            .AnyAsync();
     }
 }
 
@@ -187,7 +198,7 @@
             <!-- Row 1: Poster (2) + Description (6) -->
             <div class="row mb-3">
                 <div class="col-md-4">
-                    @if (hasPurchased)
+                    @if (hasPurchased || hasPackage)
                     {
                         <a asp-action="Watch"
                            asp-route-filmId="@Model.Film.Id"
@@ -204,7 +215,7 @@
                             </div>
                         </a>
                     }
-                    else if (user != null)
+                    else if (user != null && !(hasPurchased || hasPackage))
                     {
                         <div class="card poster-card position-relative overflow-hidden">
                             <img src="@Model.Film.PosterPath"

--- a/Netflixx/Views/Film/Index.cshtml
+++ b/Netflixx/Views/Film/Index.cshtml
@@ -82,17 +82,25 @@
                 <div class="card-footer bg-transparent">
                     @{
                         var purchased = false;
+                        var hasPackage = false;
                         if (currentUser != null)
                         {
                             int filmId = film.Id;
                             purchased = await DBContext.FilmPurchases.AnyAsync(p => p.UserID == currentUser.Id && p.FilmID == filmId);
+                            hasPackage = await DBContext.PackageSubscriptions
+                                .Where(ps => ps.UserID == currentUser.Id && ps.StartDate <= DateTime.UtcNow && ps.EndDate >= DateTime.UtcNow)
+                                .Join(DBContext.PackageFilms.Where(pf => pf.FilmID == filmId),
+                                      ps => ps.PackageID,
+                                      pf => pf.PackageID,
+                                      (ps, pf) => ps)
+                                .AnyAsync();
                         }
                     }
-                    @if (purchased)
+                    @if (purchased || hasPackage)
                     {
                         <a asp-action="Watch" asp-route-filmId="@film.Id" class="btn btn-primary">Xem ngay</a>
                     }
-                    else if (currentUser != null)
+                    else if (currentUser != null && !(purchased || hasPackage))
                     {
                         <form asp-action="Purchase" method="post" class="d-inline purchase-form">
                             @Html.AntiForgeryToken()

--- a/Netflixx/Views/Film/Type.cshtml
+++ b/Netflixx/Views/Film/Type.cshtml
@@ -107,17 +107,25 @@
                         <div class="card-footer bg-transparent">
                             @{
                                 var purchased = false;
+                                var hasPackage = false;
                                 if (currentUser != null)
                                 {
                                     int filmId = film.Id;
                                     purchased = await DBContext.FilmPurchases.AnyAsync(p => p.UserID == currentUser.Id && p.FilmID == filmId);
+                                    hasPackage = await DBContext.PackageSubscriptions
+                                        .Where(ps => ps.UserID == currentUser.Id && ps.StartDate <= DateTime.UtcNow && ps.EndDate >= DateTime.UtcNow)
+                                        .Join(DBContext.PackageFilms.Where(pf => pf.FilmID == filmId),
+                                              ps => ps.PackageID,
+                                              pf => pf.PackageID,
+                                              (ps, pf) => ps)
+                                        .AnyAsync();
                                 }
                             }
-                            @if (purchased)
+                            @if (purchased || hasPackage)
                             {
                                 <a asp-action="Watch" asp-route-filmId="@film.Id" class="btn btn-primary">Xem ngay</a>
                             }
-                            else if (currentUser != null)
+                            else if (currentUser != null && !(purchased || hasPackage))
                             {
                                 <form asp-action="Purchase" method="post" class="d-inline purchase-form">
                                     @Html.AntiForgeryToken()
@@ -163,23 +171,31 @@
                             </p>
                         </div>
                         <div class="card-footer bg-transparent">
-                            @{
-                                var purchased = false;
-                                if (currentUser != null)
-                                {
-                                    int filmId = film.Id;
-                                    purchased = await DBContext.FilmPurchases.AnyAsync(p => p.UserID == currentUser.Id && p.FilmID == filmId);
-                                }
-                            }
-                            @if (purchased)
-                            {
-                                <a asp-action="Watch" asp-route-filmId="@film.Id" class="btn btn-primary">Xem ngay</a>
-                            }
-                            else if (currentUser != null)
-                            {
-                                <form asp-action="Purchase" method="post" class="d-inline purchase-form">
-                                    @Html.AntiForgeryToken()
-                                    <input type="hidden" name="id" value="@film.Id" />
+                            @{ 
+                                var purchased = false; 
+                                var hasPackage = false; 
+                                if (currentUser != null) 
+                                { 
+                                    int filmId = film.Id; 
+                                    purchased = await DBContext.FilmPurchases.AnyAsync(p => p.UserID == currentUser.Id && p.FilmID == filmId); 
+                                    hasPackage = await DBContext.PackageSubscriptions 
+                                        .Where(ps => ps.UserID == currentUser.Id && ps.StartDate <= DateTime.UtcNow && ps.EndDate >= DateTime.UtcNow) 
+                                        .Join(DBContext.PackageFilms.Where(pf => pf.FilmID == filmId), 
+                                              ps => ps.PackageID, 
+                                              pf => pf.PackageID, 
+                                              (ps, pf) => ps) 
+                                        .AnyAsync(); 
+                                } 
+                            } 
+                            @if (purchased || hasPackage) 
+                            { 
+                                <a asp-action="Watch" asp-route-filmId="@film.Id" class="btn btn-primary">Xem ngay</a> 
+                            } 
+                            else if (currentUser != null && !(purchased || hasPackage)) 
+                            { 
+                                <form asp-action="Purchase" method="post" class="d-inline purchase-form"> 
+                                    @Html.AntiForgeryToken() 
+                                    <input type="hidden" name="id" value="@film.Id" /> 
                                     <button type="submit" class="btn btn-danger">Mua</button>
                                 </form>
                             }
@@ -224,23 +240,31 @@
                             </p>
                         </div>
                         <div class="card-footer bg-transparent">
-                            @{
-                                var purchased = false;
-                                if (currentUser != null)
-                                {
-                                    int filmId = film.Id;
-                                    purchased = await DBContext.FilmPurchases.AnyAsync(p => p.UserID == currentUser.Id && p.FilmID == filmId);
-                                }
-                            }
-                            @if (purchased)
-                            {
-                                <a asp-action="Watch" asp-route-filmId="@film.Id" class="btn btn-primary">Xem ngay</a>
-                            }
-                            else if (currentUser != null)
-                            {
-                                <form asp-action="Purchase" method="post" class="d-inline purchase-form">
-                                    @Html.AntiForgeryToken()
-                                    <input type="hidden" name="id" value="@film.Id" />
+                            @{ 
+                                var purchased = false; 
+                                var hasPackage = false; 
+                                if (currentUser != null) 
+                                { 
+                                    int filmId = film.Id; 
+                                    purchased = await DBContext.FilmPurchases.AnyAsync(p => p.UserID == currentUser.Id && p.FilmID == filmId); 
+                                    hasPackage = await DBContext.PackageSubscriptions 
+                                        .Where(ps => ps.UserID == currentUser.Id && ps.StartDate <= DateTime.UtcNow && ps.EndDate >= DateTime.UtcNow) 
+                                        .Join(DBContext.PackageFilms.Where(pf => pf.FilmID == filmId), 
+                                              ps => ps.PackageID, 
+                                              pf => pf.PackageID, 
+                                              (ps, pf) => ps) 
+                                        .AnyAsync(); 
+                                } 
+                            } 
+                            @if (purchased || hasPackage) 
+                            { 
+                                <a asp-action="Watch" asp-route-filmId="@film.Id" class="btn btn-primary">Xem ngay</a> 
+                            } 
+                            else if (currentUser != null && !(purchased || hasPackage)) 
+                            { 
+                                <form asp-action="Purchase" method="post" class="d-inline purchase-form"> 
+                                    @Html.AntiForgeryToken() 
+                                    <input type="hidden" name="id" value="@film.Id" /> 
                                     <button type="submit" class="btn btn-danger">Mua</button>
                                 </form>
                             }


### PR DESCRIPTION
## Summary
- correct film detail view to treat package subscriptions as valid purchases
- show watch button if film is included in current package on listing pages

## Testing
- `dotnet build Netflixx.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_687b383289bc8326aa8685357e2bb782