### PR TITLE
Clean up FilmPackage features

### DIFF
--- a/Netflixx/Controllers/FilmpackageController.cs
+++ b/Netflixx/Controllers/FilmpackageController.cs
@@ -110,18 +110,6 @@ namespace Netflixx.Controllers
             return View(vm);
         }
 
-        public IActionResult Buy(string packageId, string packageName, int packagePrice)
-        {
-            var model = new FilmPackageViewModel
-            {
-                PackageId = packageId,
-                PackageName = packageName,
-                PackagePrice = packagePrice
-            };
-
-            return View(model);
-        }
-
         [HttpPost]
         [ValidateAntiForgeryToken]
         public async Task<IActionResult> BuyWithCoins(int packageId)
@@ -136,7 +124,7 @@ namespace Netflixx.Controllers
             if (account == null || account.PointsBalance < package.Price)
             {
                 TempData["error"] = "Không đủ coins để mua gói.";
-                return RedirectToAction(nameof(Buy), new { packageId, packageName = package.Name, packagePrice = package.Price });
+                return RedirectToAction(nameof(Index));
             }
 
             var existing = await _context.PackageSubscriptions

--- a/Netflixx/Models/FilmPackageViewModel.cs
+++ b/Netflixx/Models/FilmPackageViewModel.cs
@@ -1,9 +1,0 @@
-﻿namespace Netflixx.Models
-{
-    public class FilmPackageViewModel
-    {
-        public string PackageId { get; set; }
-        public string PackageName { get; set; }
-        public int PackagePrice { get; set; }
-    }
-}

--- a/Netflixx/Views/Filmpackage/Index.cshtml
+++ b/Netflixx/Views/Filmpackage/Index.cshtml
@@ -474,10 +474,5 @@
                 parallax.style.backgroundPosition = `center ${speed}px`;
             });
         });
-
-
-
-
-        document.head.appendChild(style);
     </script>
 }


### PR DESCRIPTION
## Summary
- drop unused FilmPackageViewModel and Buy controller action
- redirect insufficient coins errors back to package list
- tidy FilmPackage Index page JS

## Testing
- `dotnet build Netflixx/Netflixx.csproj -clp:ErrorsOnly`
- `npm install`

------
https://chatgpt.com/codex/tasks/task_e_6880d8d068f88326b877472c39023a70