### PR TITLE
Fix post-purchase button alignment

### DIFF
--- a/Netflixx/Views/Filmpackage/Index.cshtml
+++ b/Netflixx/Views/Filmpackage/Index.cshtml
@@ -378,7 +378,9 @@
 
                 @if (owned)
                 {
-                    <a asp-controller="Film" asp-action="Type" class="btn btn-success w-75 mb-3">Đã sở hữu</a>
+                    <div class="buy-form">
+                        <a asp-controller="Film" asp-action="Type" class="btn btn-success w-75 mb-3">Đã sở hữu</a>
+                    </div>
                 }
                 else
                 {


### PR DESCRIPTION
## Summary
- keep button position consistent on film package cards by wrapping the "Đã sở hữu" button with the same `.buy-form` container

## Testing
- `npm run scss`
- `dotnet test Netflixx/Netflixx.csproj` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6880d99406c483268d6ce8fd3e98ef4f