### PR TITLE
Fix font mismatch in Filmpackage navbar

### DIFF
--- a/Netflixx/Views/Filmpackage/Billhistory.cshtml
+++ b/Netflixx/Views/Filmpackage/Billhistory.cshtml
@@ -22,7 +22,7 @@
         }
         *, *::before, *::after {
             box-sizing: border-box;
-            font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+            font-family: 'Poppins', sans-serif;
         }
 
         body {

--- a/Netflixx/Views/Filmpackage/Index.cshtml
+++ b/Netflixx/Views/Filmpackage/Index.cshtml
@@ -30,7 +30,7 @@
         }
 
         body {
-            font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+            font-family: 'Poppins', sans-serif;
             background: linear-gradient(135deg, #0f0f23 0%, #1a1a2e 50%, #16213e 100%);
             color: #fff;
             min-height: 100vh;


### PR DESCRIPTION
## Summary
- use Poppins font on Filmpackage index and bill history pages so the navbar text matches the home page
- run SCSS build

## Testing
- `npm run scss`

------
https://chatgpt.com/codex/tasks/task_e_6880f4f0e9c083269b1a5a790a06335b